### PR TITLE
Bevy 0.10 support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,8 +67,9 @@ bevy_script_api = { path = "bevy_script_api", version = "0.2.2", optional = true
 
 [dev-dependencies]
 bevy = { version = "0.10"}
+clap = { version = "4.1", features = ["derive"]}
 rand = "0.8.5"
-bevy_console = "0.6.0"
+bevy_console = "0.7.0"
 rhai-rand = "0.1" 
 
 [workspace]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,14 +59,14 @@ rhai = ["bevy_mod_scripting_rhai"]
 rhai_script_api=["bevy_script_api/rhai"]
 
 [dependencies]
-bevy = { version = "0.10", default-features = false}
+bevy = { version = "0.10.1", default-features = false}
 bevy_mod_scripting_core = { path = "bevy_mod_scripting_core", version = "0.2.2" }
 bevy_mod_scripting_lua = { path = "languages/bevy_mod_scripting_lua", version = "0.2.2", optional = true }
 bevy_mod_scripting_rhai = { path = "languages/bevy_mod_scripting_rhai", version = "0.2.2", optional = true}
 bevy_script_api = { path = "bevy_script_api", version = "0.2.2", optional = true }
 
 [dev-dependencies]
-bevy = { version = "0.10"}
+bevy = { version = "0.10.1"}
 clap = { version = "4.1", features = ["derive"]}
 rand = "0.8.5"
 bevy_console = "0.7.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,16 +59,16 @@ rhai = ["bevy_mod_scripting_rhai"]
 rhai_script_api=["bevy_script_api/rhai"]
 
 [dependencies]
-bevy = { version = "0.9", default-features = false}
+bevy = { version = "0.10", default-features = false}
 bevy_mod_scripting_core = { path = "bevy_mod_scripting_core", version = "0.2.2" }
 bevy_mod_scripting_lua = { path = "languages/bevy_mod_scripting_lua", version = "0.2.2", optional = true }
 bevy_mod_scripting_rhai = { path = "languages/bevy_mod_scripting_rhai", version = "0.2.2", optional = true}
 bevy_script_api = { path = "bevy_script_api", version = "0.2.2", optional = true }
 
 [dev-dependencies]
-bevy = { version = "0.9"}
+bevy = { version = "0.10"}
 rand = "0.8.5"
-bevy_console = "0.5.0"
+bevy_console = "0.6.0"
 rhai-rand = "0.1" 
 
 [workspace]

--- a/api_gen_config.toml
+++ b/api_gen_config.toml
@@ -166,10 +166,6 @@ type="Button"
 source="bevy_ui"
 
 [[types]]
-type="ImageMode"
-source="bevy_ui"
-
-[[types]]
 type="Display"
 source="bevy_ui"
 
@@ -212,10 +208,6 @@ type="Text2dBounds"
 source="bevy_text"
 
 [[types]]
-type="Text2dSize"
-source="bevy_text"
-
-[[types]]
 type="Text"
 source="bevy_text"
 
@@ -230,16 +222,6 @@ source="bevy_text"
 [[types]]
 type="TextStyle"
 source="bevy_text"
-
-[[types]]
-type="HorizontalAlign"
-source="bevy_text"
-
-[[types]]
-type="VerticalAlign"
-source="bevy_text"
-
-
 
 ## BEVY_TIME
 
@@ -421,10 +403,6 @@ source="bevy_render"
 
 [[types]]
 type="ScalingMode"
-source="bevy_render"
-
-[[types]]
-type="WindowOrigin"
 source="bevy_render"
 
 [[types]]

--- a/assets/scripts/game_of_life.tl
+++ b/assets/scripts/game_of_life.tl
@@ -2,7 +2,7 @@ math.randomseed(os.time())
 
 global function init()
     local LifeState = world:get_type_by_name("LifeState")
-    local life_state = world:get_component(entity,LifeState) as types.LuaLifeState
+    local life_state = world:get_component(entity,LifeState) as BevyAPI.LuaLifeState
     local cells = life_state.cells as {integer}
 
     -- set some cells alive
@@ -16,7 +16,7 @@ global function on_update()
     local LifeState = world:get_type_by_name("LifeState")
     local Settings = world:get_type_by_name("Settings")
 
-    local life_state = world:get_component(entity,LifeState) as types.LuaLifeState
+    local life_state = world:get_component(entity,LifeState) as BevyAPI.LuaLifeState
     local cells = life_state.cells as {integer}
 
     -- note that here we do not make use of LuaProxyable and just go off pure reflection

--- a/bevy_api_gen/src/config.rs
+++ b/bevy_api_gen/src/config.rs
@@ -1,7 +1,7 @@
 use std::collections::HashSet;
 
 use clap::Parser;
-use indexmap::IndexMap;
+use indexmap::{IndexMap, IndexSet};
 use rustdoc_types::{Crate, Item, ItemEnum, Visibility};
 use serde::Deserialize;
 
@@ -36,7 +36,7 @@ pub struct Config {
 
     /// Describes the set of non generic things which are representible
     /// as simple lua types and don't need UserData proxies
-    pub primitives: HashSet<String>,
+    pub primitives: IndexSet<String>,
 
     pub manual_lua_types: Vec<ManualLuaType>,
 }

--- a/bevy_api_gen/src/main.rs
+++ b/bevy_api_gen/src/main.rs
@@ -274,7 +274,7 @@ pub(crate) fn generate_macros(
     // get_doc_fragment
     writer.write_no_newline("fn get_doc_fragment(&self) -> Option<Self::DocTarget>");
     writer.open_brace();
-    writer.write_no_newline("Some(\"BevyAPI\",LuaDocFragment::new(|tw|");
+    writer.write_no_newline("Some(LuaDocFragment::new(\"BevyAPI\", |tw|");
     writer.open_brace();
     writer.write_line("tw");
     writer.write_line(".document_global_instance::<BevyAPIGlobals>().expect(\"Something went wrong documenting globals\")");

--- a/bevy_api_gen/src/writer.rs
+++ b/bevy_api_gen/src/writer.rs
@@ -45,9 +45,7 @@ impl PrettyWriter {
 
     /// Writes indentation and prefix without a newline
     fn write_indented_prefix(&mut self) {
-        (0..self.state.indentation_level)
-            .into_iter()
-            .for_each(|_| self.output.push('\t'));
+        (0..self.state.indentation_level).for_each(|_| self.output.push('\t'));
 
         if let Some(prefix) = &self.state.prefix {
             self.output.push_str(prefix);

--- a/bevy_event_priority/Cargo.toml
+++ b/bevy_event_priority/Cargo.toml
@@ -21,5 +21,5 @@ name = "bevy_event_priority"
 path = "src/lib.rs"
 
 [dependencies]
-bevy = { version = "0.9", default-features = false}
+bevy = { version = "0.10", default-features = false}
 

--- a/bevy_event_priority/Cargo.toml
+++ b/bevy_event_priority/Cargo.toml
@@ -21,5 +21,5 @@ name = "bevy_event_priority"
 path = "src/lib.rs"
 
 [dependencies]
-bevy = { version = "0.10", default-features = false}
+bevy = { version = "0.10.1", default-features = false}
 

--- a/bevy_mod_scripting_core/Cargo.toml
+++ b/bevy_mod_scripting_core/Cargo.toml
@@ -29,7 +29,7 @@ doc_always = []
 
 
 [dependencies]
-bevy = { version = "0.10", default-features = false, features=["bevy_asset","bevy_gltf","bevy_animation","bevy_core_pipeline","bevy_ui","bevy_pbr","bevy_render","bevy_text","bevy_sprite","filesystem_watcher"]}
+bevy = { version = "0.10.1", default-features = false, features=["bevy_asset","bevy_gltf","bevy_animation","bevy_core_pipeline","bevy_ui","bevy_pbr","bevy_render","bevy_text","bevy_sprite","filesystem_watcher"]}
 bevy_event_priority = {path = "../bevy_event_priority", version = "0.2.2" }
 thiserror = "1.0.31"
 paste = "1.0.7"

--- a/bevy_mod_scripting_core/Cargo.toml
+++ b/bevy_mod_scripting_core/Cargo.toml
@@ -29,7 +29,7 @@ doc_always = []
 
 
 [dependencies]
-bevy = { version = "0.9", default-features = false, features=["bevy_asset","bevy_gltf","bevy_animation","bevy_core_pipeline","bevy_ui","bevy_pbr","bevy_render","bevy_text","bevy_sprite","filesystem_watcher"]}
+bevy = { version = "0.10", default-features = false, features=["bevy_asset","bevy_gltf","bevy_animation","bevy_core_pipeline","bevy_ui","bevy_pbr","bevy_render","bevy_text","bevy_sprite","filesystem_watcher"]}
 bevy_event_priority = {path = "../bevy_event_priority", version = "0.2.2" }
 thiserror = "1.0.31"
 paste = "1.0.7"

--- a/bevy_mod_scripting_core/src/hosts.rs
+++ b/bevy_mod_scripting_core/src/hosts.rs
@@ -129,15 +129,15 @@ pub trait ScriptHost: Send + Sync + 'static + Default + Resource {
         Ok(())
     }
 
-    /// Registers the script host with the given app, and attaches handlers to deal with spawning/removing scripts at the given stage.
+    /// Registers the script host with the given app, and attaches handlers to deal with spawning/removing scripts in the given System Set.
     ///
-    /// Ideally place after any game logic which can spawn/remove/modify scripts to avoid frame lag. (typically `CoreStage::Post_Update`)
-    fn register_with_app_in_set(app: &mut App, set: impl FreeSystemSet + Clone);
+    /// Ideally place after any game logic which can spawn/remove/modify scripts to avoid frame lag. (typically `CoreSet::Post_Update`)
+    fn register_with_app_in_set(app: &mut App, set: impl FreeSystemSet);
 
-    /// Registers the script host with the given app, and attaches handlers to deal with spawning/removing scripts at the given stage.
+    /// Registers the script host with the given app, and attaches handlers to deal with spawning/removing scripts in the given Base System Set.
     ///
-    /// Ideally place after any game logic which can spawn/remove/modify scripts to avoid frame lag. (typically `CoreStage::Post_Update`)
-    fn register_with_app_in_base_set(app: &mut App, set: impl BaseSystemSet + Clone);
+    /// Ideally place after any game logic which can spawn/remove/modify scripts to avoid frame lag. (typically `CoreSet::Post_Update`)
+    fn register_with_app_in_base_set(app: &mut App, set: impl BaseSystemSet);
 }
 
 /// Implementors can modify a script context in order to enable

--- a/bevy_mod_scripting_core/src/hosts.rs
+++ b/bevy_mod_scripting_core/src/hosts.rs
@@ -1,5 +1,10 @@
 //! All script host related stuff
-use bevy::{asset::Asset, prelude::*, reflect::FromReflect};
+use bevy::{
+    asset::Asset,
+    ecs::schedule::{BaseSystemSet, FreeSystemSet},
+    prelude::*,
+    reflect::FromReflect,
+};
 use std::{
     collections::HashMap,
     iter::once,
@@ -127,7 +132,12 @@ pub trait ScriptHost: Send + Sync + 'static + Default + Resource {
     /// Registers the script host with the given app, and attaches handlers to deal with spawning/removing scripts at the given stage.
     ///
     /// Ideally place after any game logic which can spawn/remove/modify scripts to avoid frame lag. (typically `CoreStage::Post_Update`)
-    fn register_with_app(app: &mut App, stage: impl StageLabel);
+    fn register_with_app_in_set(app: &mut App, set: impl FreeSystemSet + Clone);
+
+    /// Registers the script host with the given app, and attaches handlers to deal with spawning/removing scripts at the given stage.
+    ///
+    /// Ideally place after any game logic which can spawn/remove/modify scripts to avoid frame lag. (typically `CoreStage::Post_Update`)
+    fn register_with_app_in_base_set(app: &mut App, set: impl BaseSystemSet + Clone);
 }
 
 /// Implementors can modify a script context in order to enable

--- a/bevy_mod_scripting_core/src/systems.rs
+++ b/bevy_mod_scripting_core/src/systems.rs
@@ -4,7 +4,7 @@ use bevy::{
     ecs::system::SystemState,
     prelude::{
         debug, AssetEvent, Assets, ChangeTrackers, Changed, Entity, EventReader, EventWriter,
-        FromWorld, Query, RemovedComponents, Res, ResMut, Resource, SystemLabel, World,
+        FromWorld, Query, RemovedComponents, Res, ResMut, Resource, SystemSet, World,
     },
 };
 use bevy_event_priority::PriorityEventReader;
@@ -16,8 +16,8 @@ use crate::{
 };
 
 /// Labels for scripting related systems
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, SystemLabel)]
-pub enum ScriptSystemLabel {
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, SystemSet)]
+pub enum ScriptSystemSet {
     /// event handling systems are always marked with this label
     EventHandling,
 }
@@ -98,7 +98,7 @@ pub fn script_add_synchronizer<H: ScriptHost + 'static>(
 
 /// Handles the removal of script components and their contexts
 pub fn script_remove_synchronizer<H: ScriptHost>(
-    query: RemovedComponents<ScriptCollection<H::ScriptAsset>>,
+    mut query: RemovedComponents<ScriptCollection<H::ScriptAsset>>,
     mut contexts: ResMut<ScriptContexts<H::ScriptContext>>,
 ) {
     query.iter().for_each(|v| {
@@ -210,7 +210,7 @@ pub fn script_event_handler<H: ScriptHost, const MAX: u32, const MIN: u32>(world
 pub struct CachedScriptState<H: ScriptHost> {
     pub event_state: SystemState<(
         PriorityEventReader<'static, 'static, H::ScriptEvent>,
-        EventWriter<'static, 'static, ScriptErrorEvent>,
+        EventWriter<'static, ScriptErrorEvent>,
         EventReader<'static, 'static, ScriptLoaded>,
     )>,
 }

--- a/bevy_mod_scripting_core/src/systems.rs
+++ b/bevy_mod_scripting_core/src/systems.rs
@@ -1,12 +1,6 @@
 use std::collections::HashSet;
 
-use bevy::{
-    ecs::system::SystemState,
-    prelude::{
-        debug, AssetEvent, Assets, ChangeTrackers, Changed, Entity, EventReader, EventWriter,
-        FromWorld, Query, RemovedComponents, Res, ResMut, Resource, SystemSet, World,
-    },
-};
+use bevy::{ecs::system::SystemState, prelude::*};
 use bevy_event_priority::PriorityEventReader;
 
 use crate::{
@@ -30,7 +24,7 @@ pub fn script_add_synchronizer<H: ScriptHost + 'static>(
         (
             Entity,
             &ScriptCollection<H::ScriptAsset>,
-            ChangeTrackers<ScriptCollection<H::ScriptAsset>>,
+            Ref<ScriptCollection<H::ScriptAsset>>,
         ),
         Changed<ScriptCollection<H::ScriptAsset>>,
     >,

--- a/bevy_script_api/Cargo.toml
+++ b/bevy_script_api/Cargo.toml
@@ -26,7 +26,7 @@ lua = ["bevy_mod_scripting_lua","bevy_mod_scripting_lua_derive"]
 rhai = ["bevy_mod_scripting_rhai"]
 
 [dependencies]
-bevy = { version = "0.10", default-features = false, features=["bevy_asset","bevy_gltf","bevy_animation","bevy_core_pipeline","bevy_ui","bevy_pbr","bevy_render","bevy_text","bevy_sprite","filesystem_watcher"]}
+bevy = { version = "0.10.1", default-features = false, features=["bevy_asset","bevy_gltf","bevy_animation","bevy_core_pipeline","bevy_ui","bevy_pbr","bevy_render","bevy_text","bevy_sprite","filesystem_watcher"]}
 bevy_mod_scripting_derive = { path="../bevy_mod_scripting_derive", version = "0.2.2" }
 bevy_mod_scripting_core = { path="../bevy_mod_scripting_core", version = "0.2.2" }
 parking_lot="0.12.1"

--- a/bevy_script_api/Cargo.toml
+++ b/bevy_script_api/Cargo.toml
@@ -26,7 +26,7 @@ lua = ["bevy_mod_scripting_lua","bevy_mod_scripting_lua_derive"]
 rhai = ["bevy_mod_scripting_rhai"]
 
 [dependencies]
-bevy = { version = "0.9", default-features = false, features=["bevy_asset","bevy_gltf","bevy_animation","bevy_core_pipeline","bevy_ui","bevy_pbr","bevy_render","bevy_text","bevy_sprite","filesystem_watcher"]}
+bevy = { version = "0.10", default-features = false, features=["bevy_asset","bevy_gltf","bevy_animation","bevy_core_pipeline","bevy_ui","bevy_pbr","bevy_render","bevy_text","bevy_sprite","filesystem_watcher"]}
 bevy_mod_scripting_derive = { path="../bevy_mod_scripting_derive", version = "0.2.2" }
 bevy_mod_scripting_core = { path="../bevy_mod_scripting_core", version = "0.2.2" }
 parking_lot="0.12.1"

--- a/bevy_script_api/src/common/bevy/mod.rs
+++ b/bevy_script_api/src/common/bevy/mod.rs
@@ -177,19 +177,19 @@ impl ScriptWorld {
         // TODO: maybe get an add_default impl added to ReflectComponent
         // this means that we don't require ReflectDefault for adding components!
         match comp_type.0.type_info(){
-            bevy::reflect::TypeInfo::Struct(_) => component_data.insert(&mut w, entity, &DynamicStruct::default()),
-            bevy::reflect::TypeInfo::TupleStruct(_) => component_data.insert(&mut w, entity, &DynamicTupleStruct::default()),
-            bevy::reflect::TypeInfo::Tuple(_) => component_data.insert(&mut w, entity, &DynamicTuple::default()),
-            bevy::reflect::TypeInfo::List(_) => component_data.insert(&mut w, entity, &DynamicList::default()),
-            bevy::reflect::TypeInfo::Array(_) => component_data.insert(&mut w, entity, &DynamicArray::new(Box::new([]))),
-            bevy::reflect::TypeInfo::Map(_) => component_data.insert(&mut w, entity, &DynamicMap::default()),
+            bevy::reflect::TypeInfo::Struct(_) => component_data.insert(&mut w.entity_mut(entity), &DynamicStruct::default()),
+            bevy::reflect::TypeInfo::TupleStruct(_) => component_data.insert(&mut w.entity_mut(entity), &DynamicTupleStruct::default()),
+            bevy::reflect::TypeInfo::Tuple(_) => component_data.insert(&mut w.entity_mut(entity), &DynamicTuple::default()),
+            bevy::reflect::TypeInfo::List(_) => component_data.insert(&mut w.entity_mut(entity), &DynamicList::default()),
+            bevy::reflect::TypeInfo::Array(_) => component_data.insert(&mut w.entity_mut(entity), &DynamicArray::new(Box::new([]))),
+            bevy::reflect::TypeInfo::Map(_) => component_data.insert(&mut w.entity_mut(entity), &DynamicMap::default()),
             bevy::reflect::TypeInfo::Value(_) |
-            bevy::reflect::TypeInfo::Dynamic(_) => component_data.insert(&mut w, entity,
+            bevy::reflect::TypeInfo::Dynamic(_) => component_data.insert(&mut w.entity_mut(entity),
                 comp_type.data::<ReflectDefault>().ok_or_else(||
                     ScriptError::Other(format!("Component {} is a value or dynamic type with no `ReflectDefault` type_data, cannot instantiate sensible value",comp_type.short_name())))?
                     .default()
                     .as_ref()),
-            bevy::reflect::TypeInfo::Enum(_) => component_data.insert(&mut w, entity, &DynamicEnum::default())
+            bevy::reflect::TypeInfo::Enum(_) => component_data.insert(&mut w.entity_mut(entity), &DynamicEnum::default())
         };
 
         Ok(ScriptRef::new_component_ref(
@@ -210,7 +210,7 @@ impl ScriptWorld {
             ScriptError::Other(format!("Not a component {}", comp_type.short_name()))
         })?;
 
-        Ok(component_data.reflect(&w, entity).map(|_component| {
+        Ok(component_data.reflect(w.entity(entity)).map(|_component| {
             ScriptRef::new_component_ref(component_data.clone(), entity, self.clone().into())
         }))
     }
@@ -225,7 +225,7 @@ impl ScriptWorld {
             ScriptError::Other(format!("Not a component {}", comp_type.short_name()))
         })?;
 
-        Ok(component_data.reflect(&w, entity).is_some())
+        Ok(component_data.reflect(w.entity(entity)).is_some())
     }
 
     pub fn remove_component(
@@ -237,7 +237,7 @@ impl ScriptWorld {
         let component_data = comp_type.data::<ReflectComponent>().ok_or_else(|| {
             ScriptError::Other(format!("Not a component {}", comp_type.short_name()))
         })?;
-        component_data.remove(&mut w, entity);
+        component_data.remove(&mut w.entity_mut(entity));
         Ok(())
     }
 

--- a/bevy_script_api/src/generated.rs
+++ b/bevy_script_api/src/generated.rs
@@ -76,7 +76,6 @@ use bevy::render::camera::Projection;
 use bevy::render::camera::RenderTarget;
 use bevy::render::camera::ScalingMode;
 use bevy::render::camera::Viewport;
-use bevy::render::camera::WindowOrigin;
 use bevy::render::color::Color;
 use bevy::render::mesh::skinning::SkinnedMesh;
 use bevy::render::primitives::Aabb;
@@ -91,20 +90,16 @@ use bevy::sprite::Anchor;
 use bevy::sprite::Mesh2dHandle;
 use bevy::sprite::Sprite;
 use bevy::sprite::TextureAtlasSprite;
-use bevy::text::HorizontalAlign;
 use bevy::text::Text;
 use bevy::text::Text2dBounds;
-use bevy::text::Text2dSize;
 use bevy::text::TextAlignment;
 use bevy::text::TextSection;
 use bevy::text::TextStyle;
-use bevy::text::VerticalAlign;
 use bevy::time::Stopwatch;
 use bevy::time::Timer;
 use bevy::transform::components::GlobalTransform;
 use bevy::transform::components::Transform;
 use bevy::ui::widget::Button;
-use bevy::ui::widget::ImageMode;
 use bevy::ui::AlignContent;
 use bevy::ui::AlignItems;
 use bevy::ui::AlignSelf;
@@ -608,28 +603,6 @@ impl_script_newtype! {
 }
 impl_script_newtype! {
     #[languages(on_feature(lua))]
-    ///Describes how to resize the Image node
-    bevy_ui::widget::ImageMode :
-    Clone +
-    Debug +
-    Methods
-    (
-    )
-    + Fields
-    (
-    )
-    + BinOps
-    (
-    )
-    + UnaryOps
-    (
-    )
-    lua impl
-    {
-    }
-}
-impl_script_newtype! {
-    #[languages(on_feature(lua))]
     ///Whether to use a Flexbox layout model.
     ///
     ///Part of the [`Style`] component.
@@ -826,65 +799,15 @@ impl_script_newtype! {
 }
 impl_script_newtype! {
     #[languages(on_feature(lua))]
-    ///The calculated size of text drawn in 2D scene.
-    bevy_text::Text2dSize :
-    Clone +
-    Debug +
-    Methods
-    (
-    )
-    + Fields
-    (
-        size: Wrapped(Vec2),
-    )
-    + BinOps
-    (
-    )
-    + UnaryOps
-    (
-    )
-    lua impl
-    {
-    }
-}
-impl_script_newtype! {
-    #[languages(on_feature(lua))]
     bevy_text::Text :
     Clone +
     Debug +
     Methods
     (
-        ///Returns this [`Text`] with a new [`TextAlignment`].
-        with_alignment(self:Wrapped(TextAlignment)) -> self,
-
     )
     + Fields
     (
         sections: Raw(ReflectedValue),
-        alignment: Wrapped(TextAlignment),
-    )
-    + BinOps
-    (
-    )
-    + UnaryOps
-    (
-    )
-    lua impl
-    {
-    }
-}
-impl_script_newtype! {
-    #[languages(on_feature(lua))]
-    bevy_text::TextAlignment :
-    Clone +
-    Debug +
-    Methods
-    (
-    )
-    + Fields
-    (
-        vertical: Wrapped(VerticalAlign),
-        horizontal: Wrapped(HorizontalAlign),
     )
     + BinOps
     (
@@ -935,51 +858,6 @@ impl_script_newtype! {
         font: Raw(ReflectedValue),
         font_size: Raw(f32),
         color: Wrapped(Color),
-    )
-    + BinOps
-    (
-    )
-    + UnaryOps
-    (
-    )
-    lua impl
-    {
-    }
-}
-impl_script_newtype! {
-    #[languages(on_feature(lua))]
-    ///Describes horizontal alignment preference for positioning & bounds.
-    bevy_text::HorizontalAlign :
-    Clone +
-    Debug +
-    Methods
-    (
-    )
-    + Fields
-    (
-    )
-    + BinOps
-    (
-    )
-    + UnaryOps
-    (
-    )
-    lua impl
-    {
-    }
-}
-impl_script_newtype! {
-    #[languages(on_feature(lua))]
-    ///Describes vertical alignment preference for positioning & bounds. Currently a placeholder
-    ///for future functionality.
-    bevy_text::VerticalAlign :
-    Clone +
-    Debug +
-    Methods
-    (
-    )
-    + Fields
-    (
     )
     + BinOps
     (
@@ -2406,16 +2284,9 @@ impl_script_newtype! {
     Debug +
     Methods
     (
-        ///Toggle the visibility.
-        toggle(&mut self:),
-
     )
     + Fields
     (
-        /// Indicates whether this entity is visible. Hidden values will propagate down the entity hierarchy.
-        /// If this entity is hidden, all of its descendants will be hidden as well. See [`Children`] and [`Parent`] for
-        /// hierarchy info.
-        is_visible: Raw(bool),
     )
     + BinOps
     (
@@ -2539,27 +2410,6 @@ impl_script_newtype! {
 impl_script_newtype! {
     #[languages(on_feature(lua))]
     bevy_render::camera::ScalingMode :
-    Clone +
-    Debug +
-    Methods
-    (
-    )
-    + Fields
-    (
-    )
-    + BinOps
-    (
-    )
-    + UnaryOps
-    (
-    )
-    lua impl
-    {
-    }
-}
-impl_script_newtype! {
-    #[languages(on_feature(lua))]
-    bevy_render::camera::WindowOrigin :
     Clone +
     Debug +
     Methods
@@ -2789,10 +2639,7 @@ impl_script_newtype! {
     Debug +
     Methods
     (
-        from_view_projection(Wrapped(&Mat4),Wrapped(&Vec3),Wrapped(&Vec3),Raw(f32)) -> self,
-
-        intersects_obb(&self:Wrapped(&Aabb),Wrapped(&Mat4),Raw(bool)) -> Raw(bool),
-
+        intersects_obb(&self:Wrapped(&Aabb),Wrapped(&Mat4),Raw(bool), Raw(bool)) -> Raw(bool),
     )
     + Fields
     (
@@ -2826,14 +2673,6 @@ impl_script_newtype! {
     )
     + Fields
     (
-        /// The number of samples to run for Multi-Sample Anti-Aliasing. Higher numbers result in
-        /// smoother edges.
-        /// Defaults to 4.
-        ///
-        /// Note that WGPU currently only supports 1 or 4 samples.
-        /// Ultimately we plan on supporting whatever is natively supported on a given device.
-        /// Check out this issue for more info: <https://github.com/gfx-rs/wgpu/issues/1832>
-        samples: Raw(u32),
     )
     + BinOps
     (
@@ -2870,8 +2709,6 @@ impl_script_newtype! {
     (
         /// If set, this camera will render to the given [`Viewport`] rectangle within the configured [`RenderTarget`].
         viewport: Raw(ReflectedValue),
-        /// Cameras with a lower priority will be rendered before cameras with a higher priority.
-        priority: Raw(isize),
         /// If this is set to `true`, this camera will be rendered to its specified [`RenderTarget`]. If `false`, this
         /// camera will not be rendered.
         is_active: Raw(bool),
@@ -2994,14 +2831,9 @@ impl_script_newtype! {
     )
     + Fields
     (
-        left: Raw(f32),
-        right: Raw(f32),
-        bottom: Raw(f32),
-        top: Raw(f32),
         near: Raw(f32),
         #[rename("_far")]
         far: Raw(f32),
-        window_origin: Wrapped(WindowOrigin),
         scaling_mode: Wrapped(ScalingMode),
         scale: Raw(f32),
     )
@@ -10060,7 +9892,6 @@ impl APIProvider for LuaBevyAPIProvider {
 			.process_type::<LuaStyle>()
 			.process_type::<LuaUiImage>()
 			.process_type::<LuaButton>()
-			.process_type::<LuaImageMode>()
 			.process_type::<LuaDisplay>()
 			.process_type::<LuaAnimationPlayer>()
 			.process_type::<LuaName>()
@@ -10069,15 +9900,11 @@ impl APIProvider for LuaBevyAPIProvider {
 			.process_type::<LuaChildren>()
 			.process_type::<LuaParent>()
 			.process_type::<LuaText2dBounds>()
-			.process_type::<LuaText2dSize>()
 			.process_type::<LuaText>()
 			.process_type::<bevy_mod_scripting_lua::tealr::mlu::UserDataProxy<LuaText>>()
-			.process_type::<LuaTextAlignment>()
 			.process_type::<LuaTextSection>()
 			.process_type::<bevy_mod_scripting_lua::tealr::mlu::UserDataProxy<LuaTextSection>>()
 			.process_type::<LuaTextStyle>()
-			.process_type::<LuaHorizontalAlign>()
-			.process_type::<LuaVerticalAlign>()
 			.process_type::<LuaStopwatch>()
 			.process_type::<bevy_mod_scripting_lua::tealr::mlu::UserDataProxy<LuaStopwatch>>()
 			.process_type::<LuaTimer>()
@@ -10115,7 +9942,6 @@ impl APIProvider for LuaBevyAPIProvider {
 			.process_type::<LuaComputedVisibility>()
 			.process_type::<LuaSkinnedMesh>()
 			.process_type::<LuaScalingMode>()
-			.process_type::<LuaWindowOrigin>()
 			.process_type::<LuaColor>()
 			.process_type::<bevy_mod_scripting_lua::tealr::mlu::UserDataProxy<LuaColor>>()
 			.process_type::<LuaAabb>()
@@ -10262,7 +10088,6 @@ impl APIProvider for LuaBevyAPIProvider {
         app.register_foreign_lua_type::<Style>();
         app.register_foreign_lua_type::<UiImage>();
         app.register_foreign_lua_type::<Button>();
-        app.register_foreign_lua_type::<ImageMode>();
         app.register_foreign_lua_type::<Display>();
         app.register_foreign_lua_type::<AnimationPlayer>();
         app.register_foreign_lua_type::<Name>();
@@ -10270,13 +10095,9 @@ impl APIProvider for LuaBevyAPIProvider {
         app.register_foreign_lua_type::<Children>();
         app.register_foreign_lua_type::<Parent>();
         app.register_foreign_lua_type::<Text2dBounds>();
-        app.register_foreign_lua_type::<Text2dSize>();
         app.register_foreign_lua_type::<Text>();
-        app.register_foreign_lua_type::<TextAlignment>();
         app.register_foreign_lua_type::<TextSection>();
         app.register_foreign_lua_type::<TextStyle>();
-        app.register_foreign_lua_type::<HorizontalAlign>();
-        app.register_foreign_lua_type::<VerticalAlign>();
         app.register_foreign_lua_type::<Stopwatch>();
         app.register_foreign_lua_type::<Timer>();
         app.register_foreign_lua_type::<Entity>();
@@ -10308,7 +10129,6 @@ impl APIProvider for LuaBevyAPIProvider {
         app.register_foreign_lua_type::<ComputedVisibility>();
         app.register_foreign_lua_type::<SkinnedMesh>();
         app.register_foreign_lua_type::<ScalingMode>();
-        app.register_foreign_lua_type::<WindowOrigin>();
         app.register_foreign_lua_type::<Color>();
         app.register_foreign_lua_type::<Aabb>();
         app.register_foreign_lua_type::<CubemapFrusta>();

--- a/bevy_script_api/src/generated.rs
+++ b/bevy_script_api/src/generated.rs
@@ -10358,21 +10358,21 @@ impl APIProvider for LuaBevyAPIProvider {
         app.register_foreign_lua_type::<DQuat>();
         app.register_foreign_lua_type::<EulerRot>();
         app.register_foreign_lua_type::<Rect>();
+        app.register_foreign_lua_type::<i128>();
+        app.register_foreign_lua_type::<usize>();
+        app.register_foreign_lua_type::<i16>();
+        app.register_foreign_lua_type::<u8>();
         app.register_foreign_lua_type::<u64>();
-        app.register_foreign_lua_type::<f64>();
-        app.register_foreign_lua_type::<i32>();
-        app.register_foreign_lua_type::<u32>();
-        app.register_foreign_lua_type::<u16>();
+        app.register_foreign_lua_type::<i8>();
         app.register_foreign_lua_type::<String>();
         app.register_foreign_lua_type::<f32>();
-        app.register_foreign_lua_type::<bool>();
-        app.register_foreign_lua_type::<i16>();
-        app.register_foreign_lua_type::<isize>();
-        app.register_foreign_lua_type::<u128>();
-        app.register_foreign_lua_type::<u8>();
+        app.register_foreign_lua_type::<u32>();
+        app.register_foreign_lua_type::<u16>();
         app.register_foreign_lua_type::<i64>();
-        app.register_foreign_lua_type::<usize>();
-        app.register_foreign_lua_type::<i128>();
-        app.register_foreign_lua_type::<i8>();
+        app.register_foreign_lua_type::<bool>();
+        app.register_foreign_lua_type::<u128>();
+        app.register_foreign_lua_type::<i32>();
+        app.register_foreign_lua_type::<isize>();
+        app.register_foreign_lua_type::<f64>();
     }
 }

--- a/bevy_script_api/src/generated.rs
+++ b/bevy_script_api/src/generated.rs
@@ -176,7 +176,8 @@ impl_script_newtype! {
 }
 impl_script_newtype! {
     #[languages(on_feature(lua))]
-    ///Works like [`AlignItems`] but applies only to a single item
+    ///How this item is aligned according to the cross axis.
+    ///Overrides [`AlignItems`].
     bevy_ui::AlignSelf :
     Clone +
     Debug +
@@ -446,8 +447,10 @@ impl_script_newtype! {
     )
     + Fields
     (
-        /// The size of the node
-        size: Raw(ReflectedValue),
+        /// The size of the node in logical pixels
+        size: Wrapped(Vec2),
+        /// Whether to attempt to preserve the aspect ratio when determining the layout for this item
+        preserve_aspect_ratio: Raw(bool),
     )
     + BinOps
     (
@@ -467,7 +470,7 @@ impl_script_newtype! {
     Debug +
     Methods
     (
-        ///The calculated node size as width and height in pixels
+        ///The calculated node size as width and height in logical pixels
         ///automatically calculated by [`super::flex::flex_node_system`]
         size(&self:) -> Wrapped(Vec2),
 
@@ -490,9 +493,6 @@ impl_script_newtype! {
     ///Describes the style of a UI node
     ///
     ///It uses the [Flexbox](https://cssreference.io/flexbox/) system.
-    ///
-    ///**Note:** Bevy's UI is upside down compared to how Flexbox normally works, to stay consistent with engine paradigms about layouting from
-    ///the upper left corner of the display
     bevy_ui::Style :
     Clone +
     Debug +
@@ -515,7 +515,8 @@ impl_script_newtype! {
         flex_wrap: Wrapped(FlexWrap),
         /// How items are aligned according to the cross axis
         align_items: Wrapped(AlignItems),
-        /// Like align_items but for only this item
+        /// How this item is aligned according to the cross axis.
+        /// Overrides [`AlignItems`].
         align_self: Wrapped(AlignSelf),
         /// How to align each line, only applies if flex_wrap is set to
         /// [`FlexWrap::Wrap`] and there are multiple lines of items
@@ -524,28 +525,83 @@ impl_script_newtype! {
         justify_content: Wrapped(JustifyContent),
         /// The position of the node as described by its Rect
         position: Raw(ReflectedValue),
-        /// The margin of the node
+        /// The amount of space around a node outside its border.
+        ///
+        /// If a percentage value is used, the percentage is calculated based on the width of the parent node.
+        ///
+        /// # Example
+        /// ```
+        /// # use bevy_ui::{Style, UiRect, Val};
+        /// let style = Style {
+        ///     margin: UiRect {
+        ///         left: Val::Percent(10.),
+        ///         right: Val::Percent(10.),
+        ///         top: Val::Percent(15.),
+        ///         bottom: Val::Percent(15.)
+        ///     },
+        ///     ..Default::default()
+        /// };
+        /// ```
+        /// A node with this style and a parent with dimensions of 100px by 300px, will have calculated margins of 10px on both left and right edges, and 15px on both top and bottom egdes.
         margin: Raw(ReflectedValue),
-        /// The padding of the node
+        /// The amount of space between the edges of a node and its contents.
+        ///
+        /// If a percentage value is used, the percentage is calculated based on the width of the parent node.
+        ///
+        /// # Example
+        /// ```
+        /// # use bevy_ui::{Style, UiRect, Val};
+        /// let style = Style {
+        ///     padding: UiRect {
+        ///         left: Val::Percent(1.),
+        ///         right: Val::Percent(2.),
+        ///         top: Val::Percent(3.),
+        ///         bottom: Val::Percent(4.)
+        ///     },
+        ///     ..Default::default()
+        /// };
+        /// ```
+        /// A node with this style and a parent with dimensions of 300px by 100px, will have calculated padding of 3px on the left, 6px on the right, 9px on the top and 12px on the bottom.
         padding: Raw(ReflectedValue),
-        /// The border of the node
+        /// The amount of space between the margins of a node and its padding.
+        ///
+        /// If a percentage value is used, the percentage is calculated based on the width of the parent node.
+        ///
+        /// The size of the node will be expanded if there are constraints that prevent the layout algorithm from placing the border within the existing node boundary.
+        ///
+        /// Rendering for borders is not yet implemented.
         border: Raw(ReflectedValue),
         /// Defines how much a flexbox item should grow if there's space available
         flex_grow: Raw(f32),
         /// How to shrink if there's not enough space available
         flex_shrink: Raw(f32),
-        /// The initial size of the item
+        /// The initial length of the main axis, before other properties are applied.
+        ///
+        /// If both are set, `flex_basis` overrides `size` on the main axis but it obeys the bounds defined by `min_size` and `max_size`.
         flex_basis: Wrapped(Val),
-        /// The size of the flexbox
+        /// The ideal size of the flexbox
+        ///
+        /// `size.width` is used when it is within the bounds defined by `min_size.width` and `max_size.width`.
+        /// `size.height` is used when it is within the bounds defined by `min_size.height` and `max_size.height`.
         size: Raw(ReflectedValue),
         /// The minimum size of the flexbox
+        ///
+        /// `min_size.width` is used if it is greater than either `size.width` or `max_size.width`, or both.
+        /// `min_size.height` is used if it is greater than either `size.height` or `max_size.height`, or both.
         min_size: Raw(ReflectedValue),
         /// The maximum size of the flexbox
+        ///
+        /// `max_size.width` is used if it is within the bounds defined by `min_size.width` and `size.width`.
+        /// `max_size.height` is used if it is within the bounds defined by `min_size.height` and `size.height.
         max_size: Raw(ReflectedValue),
         /// The aspect ratio of the flexbox
         aspect_ratio: Raw(ReflectedValue),
         /// How to handle overflow
         overflow: Wrapped(Overflow),
+        /// The size of the gutters between the rows and columns of the flexbox layout
+        ///
+        /// Values of `Size::UNDEFINED` and `Size::AUTO` are treated as zero.
+        gap: Raw(ReflectedValue),
     )
     + BinOps
     (
@@ -568,6 +624,12 @@ impl_script_newtype! {
     )
     + Fields
     (
+        /// Handle to the texture
+        texture: Raw(ReflectedValue),
+        /// Whether the image should be flipped along its x-axis
+        flip_x: Raw(bool),
+        /// Whether the image should be flipped along its y-axis
+        flip_y: Raw(bool),
     )
     + BinOps
     (
@@ -662,7 +724,8 @@ impl_script_newtype! {
 }
 impl_script_newtype! {
     #[languages(on_feature(lua))]
-    ///Component used to identify an entity. Stores a hash for faster comparisons
+    ///Component used to identify an entity. Stores a hash for faster comparisons.
+    ///
     ///The hash is eagerly re-computed upon each update to the name.
     ///
     ///[`Name`] should not be treated as a globally unique identifier for entities,
@@ -804,10 +867,40 @@ impl_script_newtype! {
     Debug +
     Methods
     (
+        ///Returns this [`Text`] with a new [`TextAlignment`].
+        with_alignment(self:Wrapped(TextAlignment)) -> self,
+
     )
     + Fields
     (
         sections: Raw(ReflectedValue),
+        /// The text's internal alignment.
+        /// Should not affect its position within a container.
+        alignment: Wrapped(TextAlignment),
+        /// How the text should linebreak when running out of the bounds determined by max_size
+        linebreak_behaviour: Raw(ReflectedValue),
+    )
+    + BinOps
+    (
+    )
+    + UnaryOps
+    (
+    )
+    lua impl
+    {
+    }
+}
+impl_script_newtype! {
+    #[languages(on_feature(lua))]
+    ///Describes horizontal alignment preference for positioning & bounds.
+    bevy_text::TextAlignment :
+    Clone +
+    Debug +
+    Methods
+    (
+    )
+    + Fields
+    (
     )
     + BinOps
     (
@@ -980,7 +1073,7 @@ impl_script_newtype! {
         ///```
         paused(&self:) -> Raw(bool),
 
-        ///Resets the stopwatch. The reset doesn’t affect the paused state of the stopwatch.
+        ///Resets the stopwatch. The reset doesn't affect the paused state of the stopwatch.
         ///
         ///# Examples
         ///```
@@ -1198,6 +1291,9 @@ impl_script_newtype! {
     ///The identifier is implemented using a [generational index]: a combination of an index and a generation.
     ///This allows fast insertion after data removal in an array while minimizing loss of spatial locality.
     ///
+    ///These identifiers are only valid on the [`World`] it's sourced from. Attempting to use an `Entity` to
+    ///fetch entity components or metadata from a different world will either fail or return unexpected results.
+    ///
     ///[generational index]: https://lucassardois.medium.com/generational-indices-guide-8e3c5f7fd594
     ///
     ///# Usage
@@ -1245,12 +1341,13 @@ impl_script_newtype! {
     ///[`EntityMut::id`]: crate::world::EntityMut::id
     ///[`EntityCommands`]: crate::system::EntityCommands
     ///[`Query::get`]: crate::system::Query::get
+    ///[`World`]: crate::world::World
     bevy_ecs::entity::Entity :
     Clone +
     Debug +
     Methods
     (
-        ///Creates a new entity reference with the specified `index` and a generation of 0.
+        ///Creates a new entity ID with the specified `index` and a generation of 0.
         ///
         ///# Note
         ///
@@ -1262,41 +1359,6 @@ impl_script_newtype! {
         ///In general, one should not try to synchronize the ECS by attempting to ensure that
         ///`Entity` lines up between instances, but instead insert a secondary identifier as
         ///a component.
-        ///
-        ///There are still some use cases where it might be appropriate to use this function
-        ///externally.
-        ///
-        ///## Examples
-        ///
-        ///Initializing a collection (e.g. `array` or `Vec`) with a known size:
-        ///
-        ///```no_run
-        ///# use bevy_ecs::prelude::*;
-        ///// Create a new array of size 10 and initialize it with (invalid) entities.
-        ///let mut entities: [Entity; 10] = [Entity::from_raw(0); 10];
-        ///
-        ///// ... replace the entities with valid ones.
-        ///```
-        ///
-        ///Deriving `Reflect` for a component that has an `Entity` field:
-        ///
-        ///```no_run
-        ///# use bevy_ecs::{prelude::*, component::*};
-        ///# use bevy_reflect::Reflect;
-        ///#[derive(Reflect, Component)]
-        ///#[reflect(Component)]
-        ///pub struct MyStruct {
-        ///    pub entity: Entity,
-        ///}
-        ///
-        ///impl FromWorld for MyStruct {
-        ///    fn from_world(_world: &mut World) -> Self {
-        ///        Self {
-        ///            entity: Entity::from_raw(u32::MAX),
-        ///        }
-        ///    }
-        ///}
-        ///```
         from_raw(Raw(u32)) -> Wrapped(Entity),
 
         ///Convert to a form convenient for passing outside of rust.
@@ -1355,11 +1417,11 @@ impl_script_newtype! {
     ///
     ///[`GlobalTransform`] is the position of an entity relative to the reference frame.
     ///
-    ///[`GlobalTransform`] is updated from [`Transform`] in the system
-    ///[`transform_propagate_system`](crate::transform_propagate_system).
+    ///[`GlobalTransform`] is updated from [`Transform`] by systems in the system set
+    ///[`TransformPropagate`](crate::TransformSystem::TransformPropagate).
     ///
-    ///This system runs in stage [`CoreStage::PostUpdate`](crate::CoreStage::PostUpdate). If you
-    ///update the [`Transform`] of an entity in this stage or after, you will notice a 1 frame lag
+    ///This system runs during [`CoreSet::PostUpdate`](crate::CoreSet::PostUpdate). If you
+    ///update the [`Transform`] of an entity during this set or after, you will notice a 1 frame lag
     ///before the [`GlobalTransform`] is updated.
     ///
     ///# Examples
@@ -1369,6 +1431,7 @@ impl_script_newtype! {
     ///
     ///[`global_vs_local_translation`]: https://github.com/bevyengine/bevy/blob/latest/examples/transforms/global_vs_local_translation.rs
     ///[`transform`]: https://github.com/bevyengine/bevy/blob/latest/examples/transforms/transform.rs
+    ///[`Transform`]: super::Transform
     bevy_transform::components::Transform :
     Clone +
     Debug +
@@ -1395,10 +1458,13 @@ impl_script_newtype! {
         ///all axes.
         from_scale(Wrapped(Vec3)) -> self,
 
-        ///Updates and returns this [`Transform`] by rotating it so that its unit
-        ///vector in the local negative `Z` direction is toward `target` and its
-        ///unit vector in the local `Y` direction is toward `up`.
+        ///Returns this [`Transform`] with a new rotation so that [`Transform::forward`]
+        ///points towards the `target` position and [`Transform::up`] points towards `up`.
         looking_at(self:Wrapped(Vec3),Wrapped(Vec3)) -> self,
+
+        ///Returns this [`Transform`] with a new rotation so that [`Transform::forward`]
+        ///points in the given `direction` and [`Transform::up`] points towards `up`.
+        looking_to(self:Wrapped(Vec3),Wrapped(Vec3)) -> self,
 
         ///Returns this [`Transform`] with a new translation.
         with_translation(self:Wrapped(Vec3)) -> self,
@@ -1502,9 +1568,13 @@ impl_script_newtype! {
         ///If this [`Transform`] has a parent, the `point` is relative to the [`Transform`] of the parent.
         rotate_around(&mut self:Wrapped(Vec3),Wrapped(Quat)),
 
-        ///Rotates this [`Transform`] so that its local negative `Z` direction is toward
-        ///`target` and its local `Y` direction is toward `up`.
+        ///Rotates this [`Transform`] so that [`Transform::forward`] points towards the `target` position,
+        ///and [`Transform::up`] points towards `up`.
         look_at(&mut self:Wrapped(Vec3),Wrapped(Vec3)),
+
+        ///Rotates this [`Transform`] so that [`Transform::forward`] points in the given `direction`
+        ///and [`Transform::up`] points towards `up`.
+        look_to(&mut self:Wrapped(Vec3),Wrapped(Vec3)),
 
         ///Multiplies `self` with `transform` component by component, returning the
         ///resulting [`Transform`]
@@ -1561,6 +1631,8 @@ impl_script_newtype! {
     ///Describe the position of an entity relative to the reference frame.
     ///
     ///* To place or move an entity, you should set its [`Transform`].
+    ///* [`GlobalTransform`] is fully managed by bevy, you cannot mutate it, use
+    ///  [`Transform`] instead.
     ///* To get the global transform of an entity, you should get its [`GlobalTransform`].
     ///* For transform hierarchies to work correctly, you must have both a [`Transform`] and a [`GlobalTransform`].
     ///  * You may use the [`TransformBundle`](crate::TransformBundle) to guarantee this.
@@ -1572,18 +1644,18 @@ impl_script_newtype! {
     ///
     ///[`GlobalTransform`] is the position of an entity relative to the reference frame.
     ///
-    ///[`GlobalTransform`] is updated from [`Transform`] in the system
-    ///[`transform_propagate_system`](crate::transform_propagate_system).
+    ///[`GlobalTransform`] is updated from [`Transform`] by systems in the system set
+    ///[`TransformPropagate`](crate::TransformSystem::TransformPropagate).
     ///
-    ///This system runs in stage [`CoreStage::PostUpdate`](crate::CoreStage::PostUpdate). If you
+    ///This system runs during [`CoreSet::PostUpdate`](crate::CoreSet::PostUpdate). If you
     ///update the [`Transform`] of an entity in this stage or after, you will notice a 1 frame lag
     ///before the [`GlobalTransform`] is updated.
     ///
     ///# Examples
     ///
-    ///- [`global_vs_local_translation`]
+    ///- [`transform`]
     ///
-    ///[`global_vs_local_translation`]: https://github.com/bevyengine/bevy/blob/latest/examples/transforms/global_vs_local_translation.rs
+    ///[`transform`]: https://github.com/bevyengine/bevy/blob/latest/examples/transforms/transform.rs
     bevy_transform::components::GlobalTransform :
     Clone +
     Debug +
@@ -1600,6 +1672,41 @@ impl_script_newtype! {
         ///The transform is expected to be non-degenerate and without shearing, or the output
         ///will be invalid.
         compute_transform(&self:) -> Wrapped(Transform),
+
+        ///Returns the [`Transform`] `self` would have if it was a child of an entity
+        ///with the `parent` [`GlobalTransform`].
+        ///
+        ///This is useful if you want to "reparent" an `Entity`. Say you have an entity
+        ///`e1` that you want to turn into a child of `e2`, but you want `e1` to keep the
+        ///same global transform, even after re-parenting. You would use:
+        ///
+        ///```rust
+        ///# use bevy_transform::prelude::{GlobalTransform, Transform};
+        ///# use bevy_ecs::prelude::{Entity, Query, Component, Commands};
+        ///# use bevy_hierarchy::{prelude::Parent, BuildChildren};
+        ///#[derive(Component)]
+        ///struct ToReparent {
+        ///    new_parent: Entity,
+        ///}
+        ///fn reparent_system(
+        ///    mut commands: Commands,
+        ///    mut targets: Query<(&mut Transform, Entity, &GlobalTransform, &ToReparent)>,
+        ///    transforms: Query<&GlobalTransform>,
+        ///) {
+        ///    for (mut transform, entity, initial, to_reparent) in targets.iter_mut() {
+        ///        if let Ok(parent_transform) = transforms.get(to_reparent.new_parent) {
+        ///            *transform = initial.reparented_to(parent_transform);
+        ///            commands.entity(entity)
+        ///                .remove::<ToReparent>()
+        ///                .set_parent(to_reparent.new_parent);
+        ///        }
+        ///    }
+        ///}
+        ///```
+        ///
+        ///The transform is expected to be non-degenerate and without shearing, or the output
+        ///will be invalid.
+        reparented_to(&self:Wrapped(&GlobalTransform)) -> Wrapped(Transform),
 
         ///Return the local right vector (X).
         right(&self:) -> Wrapped(Vec3),
@@ -1736,24 +1843,11 @@ impl_script_newtype! {
     ///
     ///To enable shadows, set the `shadows_enabled` property to `true`.
     ///
-    ///While directional lights contribute to the illumination of meshes regardless
-    ///of their (or the meshes') positions, currently only a limited region of the scene
-    ///(the _shadow volume_) can cast and receive shadows for any given directional light.
+    ///Shadows are produced via [cascaded shadow maps](https://developer.download.nvidia.com/SDK/10.5/opengl/src/cascaded_shadow_maps/doc/cascaded_shadow_maps.pdf).
     ///
-    ///The shadow volume is a _rectangular cuboid_, with left/right/bottom/top/near/far
-    ///planes controllable via the `shadow_projection` field. It is affected by the
-    ///directional light entity's [`GlobalTransform`], and as such can be freely repositioned in the
-    ///scene, (or even scaled!) without affecting illumination in any other way, by simply
-    ///moving (or scaling) the entity around. The shadow volume is always oriented towards the
-    ///light entity's forward direction.
+    ///To modify the cascade set up, such as the number of cascades or the maximum shadow distance,
+    ///change the [`CascadeShadowConfig`] component of the [`crate::bundle::DirectionalLightBundle`].
     ///
-    ///For smaller scenes, a static directional light with a preset volume is typically
-    ///sufficient. For larger scenes with movable cameras, you might want to introduce
-    ///a system that dynamically repositions and scales the light entity (and therefore
-    ///its shadow volume) based on the scene subject's position (e.g. a player character)
-    ///and its relative distance to the camera.
-    ///
-    ///Shadows are produced via [shadow mapping](https://en.wikipedia.org/wiki/Shadow_mapping).
     ///To control the resolution of the shadow maps, use the [`DirectionalLightShadowMap`] resource:
     ///
     ///```
@@ -1762,12 +1856,6 @@ impl_script_newtype! {
     ///App::new()
     ///    .insert_resource(DirectionalLightShadowMap { size: 2048 });
     ///```
-    ///
-    ///**Note:** Very large shadow map resolutions (> 4K) can have non-negligible performance and
-    ///memory impact, and not work properly under mobile or lower-end hardware. To improve the visual
-    ///fidelity of shadow maps, it's typically advisable to first reduce the `shadow_projection`
-    ///left/right/top/bottom to a scene-appropriate size, before ramping up the shadow map
-    ///resolution.
     bevy_pbr::DirectionalLight :
     Clone +
     Debug +
@@ -1780,8 +1868,6 @@ impl_script_newtype! {
         /// Illuminance in lux
         illuminance: Raw(f32),
         shadows_enabled: Raw(bool),
-        /// A projection that controls the volume in which shadow maps are rendered
-        shadow_projection: Wrapped(OrthographicProjection),
         shadow_depth_bias: Raw(f32),
         /// A bias applied along the direction of the fragment's surface normal. It is scaled to the
         /// shadow map's texel size so that it is automatically adjusted to the orthographic projection.
@@ -2167,18 +2253,25 @@ impl_script_newtype! {
     Debug +
     Methods
     (
+        ///Create a new [`TextureAtlasSprite`] with a sprite index,
+        ///it should be valid in the corresponding [`TextureAtlas`]
         new(Raw(usize)) -> Wrapped(TextureAtlasSprite),
 
     )
     + Fields
     (
+        /// The tint color used to draw the sprite, defaulting to [`Color::WHITE`]
         color: Wrapped(Color),
+        /// Texture index in [`TextureAtlas`]
         index: Raw(usize),
+        /// Whether to flip the sprite in the X axis
         flip_x: Raw(bool),
+        /// Whether to flip the sprite in the Y axis
         flip_y: Raw(bool),
         /// An optional custom size for the sprite that will be used when rendering, instead of the size
         /// of the sprite's image in the atlas
         custom_size: Raw(ReflectedValue),
+        /// [`Anchor`] point of the sprite in the world
         anchor: Wrapped(Anchor),
     )
     + BinOps
@@ -2277,8 +2370,12 @@ impl_script_newtype! {
 impl_script_newtype! {
     #[languages(on_feature(lua))]
     ///User indication of whether an entity is visible. Propagates down the entity hierarchy.
-    ///If an entity is hidden in this way,  all [`Children`] (and all of their children and so on) will also be hidden.
-    ///This is done by setting the values of their [`ComputedVisibility`] component.
+    ///
+    ///If an entity is hidden in this way, all [`Children`] (and all of their children and so on) who
+    ///are set to `Inherited` will also be hidden.
+    ///
+    ///This is done by the `visibility_propagate_system` which uses the entity hierarchy and
+    ///`Visibility` to set the values of each entity's [`ComputedVisibility`] component.
     bevy_render::view::visibility::Visibility :
     Clone +
     Debug +
@@ -2345,22 +2442,21 @@ impl_script_newtype! {
     (
         ///Whether this entity is visible to something this frame. This is true if and only if [`Self::is_visible_in_hierarchy`] and [`Self::is_visible_in_view`]
         ///are true. This is the canonical method to call to determine if an entity should be drawn.
-        ///This value is updated in [`CoreStage::PostUpdate`] during the [`VisibilitySystems::CheckVisibility`] system label. Reading it from the
-        ///[`CoreStage::Update`] stage will yield the value from the previous frame.
+        ///This value is updated in [`CoreSet::PostUpdate`] by the [`VisibilitySystems::CheckVisibility`] system set.
+        ///Reading it during [`CoreSet::Update`] will yield the value from the previous frame.
         is_visible(&self:) -> Raw(bool),
 
         ///Whether this entity is visible in the entity hierarchy, which is determined by the [`Visibility`] component.
         ///This takes into account "visibility inheritance". If any of this entity's ancestors (see [`Parent`]) are hidden, this entity
-        ///will be hidden as well. This value is updated in the [`CoreStage::PostUpdate`] stage in the
-        ///[`VisibilitySystems::VisibilityPropagate`] system label.
+        ///will be hidden as well. This value is updated in the [`VisibilitySystems::VisibilityPropagate`], which lives under the [`CoreSet::PostUpdate`] set.
         is_visible_in_hierarchy(&self:) -> Raw(bool),
 
         ///Whether this entity is visible in _any_ view (Cameras, Lights, etc). Each entity type (and view type) should choose how to set this
         ///value. For cameras and drawn entities, this will take into account [`RenderLayers`].
         ///
-        ///This value is reset to `false` every frame in [`VisibilitySystems::VisibilityPropagate`] during [`CoreStage::PostUpdate`].
-        ///Each entity type then chooses how to set this field in the [`CoreStage::PostUpdate`] stage in the
-        ///[`VisibilitySystems::CheckVisibility`] system label. Meshes might use frustum culling to decide if they are visible in a view.
+        ///This value is reset to `false` every frame in [`VisibilitySystems::VisibilityPropagate`] during [`CoreSet::PostUpdate`].
+        ///Each entity type then chooses how to set this field in the [`VisibilitySystems::CheckVisibility`] system set, under [`CoreSet::PostUpdate`].
+        ///Meshes might use frustum culling to decide if they are visible in a view.
         ///Other entities might just set this to `true` every frame.
         is_visible_in_view(&self:) -> Raw(bool),
 
@@ -2536,8 +2632,20 @@ impl_script_newtype! {
         ///Get blue in sRGB colorspace.
         b(&self:) -> Raw(f32),
 
+        ///Returns this color with red set to a new value in sRGB colorspace.
+        with_r(self:Raw(f32)) -> self,
+
+        ///Returns this color with green set to a new value in sRGB colorspace.
+        with_g(self:Raw(f32)) -> self,
+
+        ///Returns this color with blue set to a new value in sRGB colorspace.
+        with_b(self:Raw(f32)) -> self,
+
         ///Get alpha.
         a(&self:) -> Raw(f32),
+
+        ///Returns this color with a new alpha value.
+        with_a(self:Raw(f32)) -> self,
 
         ///Converts a `Color` to variant `Color::Rgba`
         as_rgba(Wrapped(&Color):) -> Wrapped(Color),
@@ -2547,6 +2655,9 @@ impl_script_newtype! {
 
         ///Converts a `Color` to variant `Color::Hsla`
         as_hsla(Wrapped(&Color):) -> Wrapped(Color),
+
+        ///Converts a `Color` to variant `Color::Lcha`
+        as_lcha(Wrapped(&Color):) -> Wrapped(Color),
 
         ///Converts `Color` to a `u32` from sRGB colorspace.
         ///
@@ -2581,7 +2692,7 @@ impl_script_newtype! {
 }
 impl_script_newtype! {
     #[languages(on_feature(lua))]
-    ///An Axis-Aligned Bounding Box
+    ///An axis-aligned bounding box.
     bevy_render::primitives::Aabb :
     Clone +
     Debug +
@@ -2639,7 +2750,15 @@ impl_script_newtype! {
     Debug +
     Methods
     (
-        intersects_obb(&self:Wrapped(&Aabb),Wrapped(&Mat4),Raw(bool), Raw(bool)) -> Raw(bool),
+        ///Returns a frustum derived from `view_projection`.
+        from_view_projection(Wrapped(&Mat4)) -> self,
+
+        ///Returns a frustum derived from `view_projection`, but with a custom
+        ///far plane.
+        from_view_projection_custom_far(Wrapped(&Mat4),Wrapped(&Vec3),Wrapped(&Vec3),Raw(f32)) -> self,
+
+        intersects_obb(&self:Wrapped(&Aabb),Wrapped(&Mat4),Raw(bool),Raw(bool)) -> Raw(bool),
+
     )
     + Fields
     (
@@ -2658,18 +2777,26 @@ impl_script_newtype! {
     #[languages(on_feature(lua))]
     ///Configuration resource for [Multi-Sample Anti-Aliasing](https://en.wikipedia.org/wiki/Multisample_anti-aliasing).
     ///
+    ///The number of samples to run for Multi-Sample Anti-Aliasing. Higher numbers result in
+    ///smoother edges.
+    ///Defaults to 4 samples.
+    ///
+    ///Note that web currently only supports 1 or 4 samples.
+    ///
     ///# Example
     ///```
     ///# use bevy_app::prelude::App;
     ///# use bevy_render::prelude::Msaa;
     ///App::new()
-    ///    .insert_resource(Msaa { samples: 4 })
+    ///    .insert_resource(Msaa::default())
     ///    .run();
     ///```
     bevy_render::view::Msaa :
     Clone +
     Methods
     (
+        samples(&self:) -> Raw(u32),
+
     )
     + Fields
     (
@@ -2709,6 +2836,8 @@ impl_script_newtype! {
     (
         /// If set, this camera will render to the given [`Viewport`] rectangle within the configured [`RenderTarget`].
         viewport: Raw(ReflectedValue),
+        /// Cameras with a higher order are rendered later, and thus on top of lower order cameras.
+        order: Raw(isize),
         /// If this is set to `true`, this camera will be rendered to its specified [`RenderTarget`]. If `false`, this
         /// camera will not be rendered.
         is_active: Raw(bool),
@@ -2719,6 +2848,11 @@ impl_script_newtype! {
         /// some cases. When rendering with WebGL, this will crash if MSAA is enabled.
         /// See <https://github.com/bevyengine/bevy/pull/3425> for details.
         hdr: Raw(bool),
+        /// If this is enabled, a previous camera exists that shares this camera's render target, and this camera has MSAA enabled, then the previous camera's
+        /// outputs will be written to the intermediate multi-sampled render target textures for this camera. This enables cameras with MSAA enabled to
+        /// "write their results on top" of previous camera results, and include them as a part of their render results. This is enabled by default to ensure
+        /// cameras with MSAA enabled layer their results in the same way as cameras without MSAA enabled by default.
+        msaa_writeback: Raw(bool),
     )
     + BinOps
     (
@@ -2817,6 +2951,14 @@ impl_script_newtype! {
 }
 impl_script_newtype! {
     #[languages(on_feature(lua))]
+    ///Project a 3D space onto a 2D surface using parallel lines, i.e., unlike [`PerspectiveProjection`],
+    ///the size of objects remains the same regardless of their distance to the camera.
+    ///
+    ///The volume contained in the projection is called the *view frustum*. Since the viewport is rectangular
+    ///and projection lines are parallel, the view frustum takes the shape of a cuboid.
+    ///
+    ///Note that the scale of the projection and the apparent size of objects are inversely proportional.
+    ///As the size of the projection increases, the size of objects decreases.
     bevy_render::camera::OrthographicProjection :
     Clone +
     Debug +
@@ -2831,11 +2973,50 @@ impl_script_newtype! {
     )
     + Fields
     (
+        /// The distance of the near clipping plane in world units.
+        ///
+        /// Objects closer than this will not be rendered.
+        ///
+        /// Defaults to `0.0`
         near: Raw(f32),
+        /// The distance of the far clipping plane in world units.
+        ///
+        /// Objects further than this will not be rendered.
+        ///
+        /// Defaults to `1000.0`
         #[rename("_far")]
         far: Raw(f32),
+        /// Specifies the origin of the viewport as a normalized position from 0 to 1, where (0, 0) is the bottom left
+        /// and (1, 1) is the top right. This determines where the camera's position sits inside the viewport.
+        ///
+        /// When the projection scales due to viewport resizing, the position of the camera, and thereby `viewport_origin`,
+        /// remains at the same relative point.
+        ///
+        /// Consequently, this is pivot point when scaling. With a bottom left pivot, the projection will expand
+        /// upwards and to the right. With a top right pivot, the projection will expand downwards and to the left.
+        /// Values in between will caused the projection to scale proportionally on each axis.
+        ///
+        /// Defaults to `(0.5, 0.5)`, which makes scaling affect opposite sides equally, keeping the center
+        /// point of the viewport centered.
+        viewport_origin: Wrapped(Vec2),
+        /// How the projection will scale when the viewport is resized.
+        ///
+        /// Defaults to `ScalingMode::WindowScale(1.0)`
         scaling_mode: Wrapped(ScalingMode),
+        /// Scales the projection in world units.
+        ///
+        /// As scale increases, the apparent size of objects decreases, and vice versa.
+        ///
+        /// Defaults to `1.0`
         scale: Raw(f32),
+        /// The area that the projection covers relative to `viewport_origin`.
+        ///
+        /// Bevy's [`camera_system`](crate::camera::camera_system) automatically
+        /// updates this value when the viewport is resized depending on `OrthographicProjection`'s other fields.
+        /// In this case, `area` should not be manually modified.
+        ///
+        /// It may be necessary to set this manually for shadow projections and such.
+        area: Wrapped(Rect),
     )
     + BinOps
     (
@@ -3123,6 +3304,9 @@ impl_script_newtype! {
         ///- `-1.0` if the number is negative, `-0.0` or `NEG_INFINITY`
         ///- `NAN` if the number is `NAN`
         signum(self:) -> self,
+
+        ///Returns a vector with signs of `rhs` and the magnitudes of `self`.
+        copysign(self:self) -> self,
 
         ///Returns a bitmask with the lowest 2 bits set to the sign bits from the elements of `self`.
         ///
@@ -3478,6 +3662,9 @@ impl_script_newtype! {
         ///- `-1.0` if the number is negative, `-0.0` or `NEG_INFINITY`
         ///- `NAN` if the number is `NAN`
         signum(self:) -> self,
+
+        ///Returns a vector with signs of `rhs` and the magnitudes of `self`.
+        copysign(self:self) -> self,
 
         ///Returns a bitmask with the lowest 3 bits set to the sign bits from the elements of `self`.
         ///
@@ -3839,6 +4026,9 @@ impl_script_newtype! {
         ///- `NAN` if the number is `NAN`
         signum(self:) -> self,
 
+        ///Returns a vector with signs of `rhs` and the magnitudes of `self`.
+        copysign(self:self) -> self,
+
         ///Returns a bitmask with the lowest 3 bits set to the sign bits from the elements of `self`.
         ///
         ///A negative element results in a `1` bit and a positive element in a `0` bit.  Element `x` goes
@@ -4188,6 +4378,9 @@ impl_script_newtype! {
         ///- `-1.0` if the number is negative, `-0.0` or `NEG_INFINITY`
         ///- `NAN` if the number is `NAN`
         signum(self:) -> self,
+
+        ///Returns a vector with signs of `rhs` and the magnitudes of `self`.
+        copysign(self:self) -> self,
 
         ///Returns a bitmask with the lowest 4 bits set to the sign bits from the elements of `self`.
         ///
@@ -4727,6 +4920,9 @@ impl_script_newtype! {
         ///- `NAN` if the number is `NAN`
         signum(self:) -> self,
 
+        ///Returns a vector with signs of `rhs` and the magnitudes of `self`.
+        copysign(self:self) -> self,
+
         ///Returns a bitmask with the lowest 2 bits set to the sign bits from the elements of `self`.
         ///
         ///A negative element results in a `1` bit and a positive element in a `0` bit.  Element `x` goes
@@ -5082,6 +5278,9 @@ impl_script_newtype! {
         ///- `NAN` if the number is `NAN`
         signum(self:) -> self,
 
+        ///Returns a vector with signs of `rhs` and the magnitudes of `self`.
+        copysign(self:self) -> self,
+
         ///Returns a bitmask with the lowest 3 bits set to the sign bits from the elements of `self`.
         ///
         ///A negative element results in a `1` bit and a positive element in a `0` bit.  Element `x` goes
@@ -5434,6 +5633,9 @@ impl_script_newtype! {
         ///- `NAN` if the number is `NAN`
         signum(self:) -> self,
 
+        ///Returns a vector with signs of `rhs` and the magnitudes of `self`.
+        copysign(self:self) -> self,
+
         ///Returns a bitmask with the lowest 4 bits set to the sign bits from the elements of `self`.
         ///
         ///A negative element results in a `1` bit and a positive element in a `0` bit.  Element `x` goes
@@ -5756,10 +5958,13 @@ impl_script_newtype! {
 
         ///Returns a vector with elements representing the sign of `self`.
         ///
-        ///- `1.0` if the number is positive, `+0.0` or `INFINITY`
-        ///- `-1.0` if the number is negative, `-0.0` or `NEG_INFINITY`
-        ///- `NAN` if the number is `NAN`
+        /// - `0` if the number is zero
+        /// - `1` if the number is positive
+        /// - `-1` if the number is negative
         signum(self:) -> self,
+
+        ///Returns a vector with signs of `rhs` and the magnitudes of `self`.
+        copysign(self:self) -> self,
 
         ///Returns a bitmask with the lowest 2 bits set to the sign bits from the elements of `self`.
         ///
@@ -5936,10 +6141,13 @@ impl_script_newtype! {
 
         ///Returns a vector with elements representing the sign of `self`.
         ///
-        ///- `1.0` if the number is positive, `+0.0` or `INFINITY`
-        ///- `-1.0` if the number is negative, `-0.0` or `NEG_INFINITY`
-        ///- `NAN` if the number is `NAN`
+        /// - `0` if the number is zero
+        /// - `1` if the number is positive
+        /// - `-1` if the number is negative
         signum(self:) -> self,
+
+        ///Returns a vector with signs of `rhs` and the magnitudes of `self`.
+        copysign(self:self) -> self,
 
         ///Returns a bitmask with the lowest 3 bits set to the sign bits from the elements of `self`.
         ///
@@ -6102,10 +6310,13 @@ impl_script_newtype! {
 
         ///Returns a vector with elements representing the sign of `self`.
         ///
-        ///- `1.0` if the number is positive, `+0.0` or `INFINITY`
-        ///- `-1.0` if the number is negative, `-0.0` or `NEG_INFINITY`
-        ///- `NAN` if the number is `NAN`
+        /// - `0` if the number is zero
+        /// - `1` if the number is positive
+        /// - `-1` if the number is negative
         signum(self:) -> self,
+
+        ///Returns a vector with signs of `rhs` and the magnitudes of `self`.
+        copysign(self:self) -> self,
 
         ///Returns a bitmask with the lowest 4 bits set to the sign bits from the elements of `self`.
         ///
@@ -9658,6 +9869,10 @@ impl bevy_mod_scripting_lua::tealr::mlu::ExportInstances for BevyAPIGlobals {
         instances: &mut T,
     ) -> bevy_mod_scripting_lua::tealr::mlu::mlua::Result<()> {
         instances.add_instance(
+            "UiImage",
+            bevy_mod_scripting_lua::tealr::mlu::UserDataProxy::<LuaUiImage>::new,
+        )?;
+        instances.add_instance(
             "Name",
             bevy_mod_scripting_lua::tealr::mlu::UserDataProxy::<LuaName>::new,
         )?;
@@ -9891,6 +10106,7 @@ impl APIProvider for LuaBevyAPIProvider {
 			.process_type::<LuaNode>()
 			.process_type::<LuaStyle>()
 			.process_type::<LuaUiImage>()
+			.process_type::<bevy_mod_scripting_lua::tealr::mlu::UserDataProxy<LuaUiImage>>()
 			.process_type::<LuaButton>()
 			.process_type::<LuaDisplay>()
 			.process_type::<LuaAnimationPlayer>()
@@ -9902,6 +10118,7 @@ impl APIProvider for LuaBevyAPIProvider {
 			.process_type::<LuaText2dBounds>()
 			.process_type::<LuaText>()
 			.process_type::<bevy_mod_scripting_lua::tealr::mlu::UserDataProxy<LuaText>>()
+			.process_type::<LuaTextAlignment>()
 			.process_type::<LuaTextSection>()
 			.process_type::<bevy_mod_scripting_lua::tealr::mlu::UserDataProxy<LuaTextSection>>()
 			.process_type::<LuaTextStyle>()
@@ -10096,6 +10313,7 @@ impl APIProvider for LuaBevyAPIProvider {
         app.register_foreign_lua_type::<Parent>();
         app.register_foreign_lua_type::<Text2dBounds>();
         app.register_foreign_lua_type::<Text>();
+        app.register_foreign_lua_type::<TextAlignment>();
         app.register_foreign_lua_type::<TextSection>();
         app.register_foreign_lua_type::<TextStyle>();
         app.register_foreign_lua_type::<Stopwatch>();
@@ -10178,21 +10396,21 @@ impl APIProvider for LuaBevyAPIProvider {
         app.register_foreign_lua_type::<DQuat>();
         app.register_foreign_lua_type::<EulerRot>();
         app.register_foreign_lua_type::<Rect>();
-        app.register_foreign_lua_type::<i128>();
-        app.register_foreign_lua_type::<usize>();
-        app.register_foreign_lua_type::<i16>();
-        app.register_foreign_lua_type::<u8>();
+        app.register_foreign_lua_type::<f64>();
+        app.register_foreign_lua_type::<i64>();
+        app.register_foreign_lua_type::<String>();
         app.register_foreign_lua_type::<u64>();
         app.register_foreign_lua_type::<i8>();
-        app.register_foreign_lua_type::<String>();
-        app.register_foreign_lua_type::<f32>();
-        app.register_foreign_lua_type::<u32>();
-        app.register_foreign_lua_type::<u16>();
-        app.register_foreign_lua_type::<i64>();
-        app.register_foreign_lua_type::<bool>();
-        app.register_foreign_lua_type::<u128>();
         app.register_foreign_lua_type::<i32>();
         app.register_foreign_lua_type::<isize>();
-        app.register_foreign_lua_type::<f64>();
+        app.register_foreign_lua_type::<u16>();
+        app.register_foreign_lua_type::<f32>();
+        app.register_foreign_lua_type::<i16>();
+        app.register_foreign_lua_type::<u128>();
+        app.register_foreign_lua_type::<i128>();
+        app.register_foreign_lua_type::<usize>();
+        app.register_foreign_lua_type::<u32>();
+        app.register_foreign_lua_type::<u8>();
+        app.register_foreign_lua_type::<bool>();
     }
 }

--- a/bevy_script_api/src/generated.rs
+++ b/bevy_script_api/src/generated.rs
@@ -10396,21 +10396,21 @@ impl APIProvider for LuaBevyAPIProvider {
         app.register_foreign_lua_type::<DQuat>();
         app.register_foreign_lua_type::<EulerRot>();
         app.register_foreign_lua_type::<Rect>();
-        app.register_foreign_lua_type::<f64>();
-        app.register_foreign_lua_type::<i64>();
-        app.register_foreign_lua_type::<String>();
-        app.register_foreign_lua_type::<u64>();
-        app.register_foreign_lua_type::<i8>();
-        app.register_foreign_lua_type::<i32>();
-        app.register_foreign_lua_type::<isize>();
-        app.register_foreign_lua_type::<u16>();
-        app.register_foreign_lua_type::<f32>();
-        app.register_foreign_lua_type::<i16>();
-        app.register_foreign_lua_type::<u128>();
-        app.register_foreign_lua_type::<i128>();
         app.register_foreign_lua_type::<usize>();
+        app.register_foreign_lua_type::<isize>();
+        app.register_foreign_lua_type::<f32>();
+        app.register_foreign_lua_type::<f64>();
+        app.register_foreign_lua_type::<u128>();
+        app.register_foreign_lua_type::<u64>();
         app.register_foreign_lua_type::<u32>();
+        app.register_foreign_lua_type::<u16>();
         app.register_foreign_lua_type::<u8>();
+        app.register_foreign_lua_type::<i128>();
+        app.register_foreign_lua_type::<i64>();
+        app.register_foreign_lua_type::<i32>();
+        app.register_foreign_lua_type::<i16>();
+        app.register_foreign_lua_type::<i8>();
+        app.register_foreign_lua_type::<String>();
         app.register_foreign_lua_type::<bool>();
     }
 }

--- a/bevy_script_api/src/lua/std.rs
+++ b/bevy_script_api/src/lua/std.rs
@@ -34,7 +34,7 @@ macro_rules! impl_proxyable_by_copy(
         paste! {
             $(
                 impl $crate::lua::LuaProxyable for $num_ty {
-                    fn ref_to_lua< 'lua>(self_: $crate::script_ref::ScriptRef,lua: & 'lua tealr::mlu::mlua::Lua) -> tealr::mlu::mlua::Result<tealr::mlu::mlua::Value< 'lua> >  {
+                    fn ref_to_lua(self_: $crate::script_ref::ScriptRef,lua: & tealr::mlu::mlua::Lua) -> tealr::mlu::mlua::Result<tealr::mlu::mlua::Value< '_> >  {
                         self_.get_typed(|self_ : &Self| self_.to_lua(lua))?
                     }
 

--- a/bevy_script_api/src/sub_reflect.rs
+++ b/bevy_script_api/src/sub_reflect.rs
@@ -348,7 +348,7 @@ impl ReflectPath {
             ReflectBase::Component { comp, entity } => {
                 let g = world_ptr.read();
 
-                let ref_ = self.walk_path(comp.reflect(&g, *entity).ok_or_else(|| {
+                let ref_ = self.walk_path(comp.reflect(g.entity(*entity)).ok_or_else(|| {
                     ReflectionError::InvalidBaseReference {
                         base: self.base.to_string(),
                         reason: "Given component does not exist on this entity".to_owned(),
@@ -396,8 +396,9 @@ impl ReflectPath {
             ReflectBase::Component { comp, entity } => {
                 let mut g = world_ptr.write();
 
+                let mut e = g.entity_mut(*entity);
                 let ref_ = self.walk_path_mut(
-                    comp.reflect_mut(&mut g, *entity)
+                    comp.reflect_mut(&mut e)
                         .ok_or_else(|| ReflectionError::InvalidBaseReference {
                             base: self.base.to_string(),
                             reason: "Given component does not exist on this entity".to_owned(),

--- a/examples/lua/bevy_api.rs
+++ b/examples/lua/bevy_api.rs
@@ -73,8 +73,8 @@ fn main() -> std::io::Result<()> {
         .register_foreign_lua_type::<Option<Vec<bool>>>()
         .init_resource::<MyResource>()
         // this stage handles addition and removal of script contexts, we can safely use `CoreStage::PostUpdate`
-        .add_script_host::<LuaScriptHost<()>, _>(CoreStage::PostUpdate)
-        .add_script_handler_stage::<LuaScriptHost<()>,_,0,0>(CoreStage::PostUpdate)
+        .add_script_host_to_base_set::<LuaScriptHost<()>, _>(CoreSet::PostUpdate)
+        .add_script_handler_to_base_set::<LuaScriptHost<()>,_,0,0>(CoreSet::PostUpdate)
         .add_api_provider::<LuaScriptHost<()>>(Box::new(LuaBevyAPIProvider))
         .add_system(
             |world: &mut World| {

--- a/examples/lua/bevy_api.rs
+++ b/examples/lua/bevy_api.rs
@@ -72,7 +72,7 @@ fn main() -> std::io::Result<()> {
         .register_foreign_lua_type::<Option<bool>>()
         .register_foreign_lua_type::<Option<Vec<bool>>>()
         .init_resource::<MyResource>()
-        // this stage handles addition and removal of script contexts, we can safely use `CoreStage::PostUpdate`
+        // this system set handles addition and removal of script contexts, we can safely use `CoreSet::PostUpdate`
         .add_script_host_to_base_set::<LuaScriptHost<()>, _>(CoreSet::PostUpdate)
         .add_script_handler_to_base_set::<LuaScriptHost<()>,_,0,0>(CoreSet::PostUpdate)
         .add_api_provider::<LuaScriptHost<()>>(Box::new(LuaBevyAPIProvider))

--- a/examples/lua/complex_game_loop.rs
+++ b/examples/lua/complex_game_loop.rs
@@ -165,9 +165,7 @@ fn main() -> std::io::Result<()> {
         )
         // main update logic system set (every frame)
         .add_system(do_update)
-
         // --- script handler system sets
-
         // pre_physics,     priority: [0,10] inclusive
         .configure_set(ComplexGameLoopSet::PrePhysicsScripts.after(ComplexGameLoopSet::PrePhysics))
         .add_system(

--- a/examples/lua/console_integration.rs
+++ b/examples/lua/console_integration.rs
@@ -1,6 +1,7 @@
 use bevy::{ecs::event::Events, prelude::*};
 use bevy_console::{AddConsoleCommand, ConsoleCommand, ConsolePlugin, PrintConsoleLine};
 use bevy_mod_scripting::prelude::*;
+use clap::Parser;
 
 use std::sync::Mutex;
 
@@ -31,7 +32,7 @@ impl APIProvider for LuaAPIProvider {
 
                     let mut events: Mut<Events<PrintConsoleLine>> =
                         world.get_resource_mut().unwrap();
-                    events.send(PrintConsoleLine { line: msg });
+                    events.send(PrintConsoleLine { line: msg.into() });
 
                     // return something
                     Ok(())
@@ -70,7 +71,7 @@ pub fn forward_script_err_to_console(
 ) {
     for e in r.iter() {
         w.send(PrintConsoleLine {
-            line: format!("ERROR:{}", e.error),
+            line: format!("ERROR:{}", e.error).into(),
         });
     }
 }
@@ -78,8 +79,8 @@ pub fn forward_script_err_to_console(
 // we use bevy-debug-console to demonstrate how this can fit in in the runtime of a game
 // note that using just the entity id instead of the full Entity has issues,
 // but since we aren't despawning/spawning entities this works in our case
-#[derive(ConsoleCommand)]
-#[console_command(name = "run_script")]
+#[derive(Parser, ConsoleCommand)]
+#[command(name = "run_script")]
 ///Runs a Lua script from the `assets/scripts` directory
 pub struct RunScriptCmd {
     /// the relative path to the script, e.g.: `/hello.lua` for a script located in `assets/scripts/hello.lua`
@@ -149,8 +150,8 @@ pub fn delete_script_cmd(
     }
 }
 
-#[derive(ConsoleCommand)]
-#[console_command(name = "delete_script")]
+#[derive(Parser, ConsoleCommand)]
+#[command(name = "delete_script")]
 ///Runs a Lua script from the `assets/scripts` directory
 pub struct DeleteScriptCmd {
     /// the name of the script
@@ -170,10 +171,10 @@ fn main() -> std::io::Result<()> {
         .add_console_command::<RunScriptCmd, _>(run_script_cmd)
         .add_console_command::<DeleteScriptCmd, _>(delete_script_cmd)
         // choose and register the script hosts you want to use
-        .add_script_host::<LuaScriptHost<()>, _>(CoreStage::PostUpdate)
+        .add_script_host_to_base_set::<LuaScriptHost<()>, _>(CoreSet::PostUpdate)
         .add_api_provider::<LuaScriptHost<()>>(Box::new(LuaAPIProvider))
         .add_api_provider::<LuaScriptHost<()>>(Box::new(LuaBevyAPIProvider))
-        .add_script_handler_stage::<LuaScriptHost<()>, _, 0, 0>(CoreStage::PostUpdate)
+        .add_script_handler_to_base_set::<LuaScriptHost<()>, _, 0, 0>(CoreSet::PostUpdate)
         // add your systems
         .add_system(trigger_on_update_lua)
         .add_system(forward_script_err_to_console);

--- a/examples/lua/console_integration.rs
+++ b/examples/lua/console_integration.rs
@@ -54,7 +54,7 @@ impl APIProvider for LuaAPIProvider {
 }
 
 /// sends updates to script host which are then handled by the scripts
-/// in the designated stage
+/// in their designated system sets
 pub fn trigger_on_update_lua(mut w: PriorityEventWriter<LuaEvent<()>>) {
     let event = LuaEvent {
         hook_name: "on_update".to_string(),

--- a/examples/lua/coroutines.rs
+++ b/examples/lua/coroutines.rs
@@ -36,8 +36,8 @@ fn main() -> std::io::Result<()> {
         // the script with id 0
         // or the script with id 1
         .add_system(do_update)
-        .add_script_handler_stage::<LuaScriptHost<()>, _, 0, 0>(CoreStage::PostUpdate)
-        .add_script_host::<LuaScriptHost<()>, _>(CoreStage::PostUpdate);
+        .add_script_handler_to_base_set::<LuaScriptHost<()>, _, 0, 0>(CoreSet::PostUpdate)
+        .add_script_host_to_base_set::<LuaScriptHost<()>, _>(CoreSet::PostUpdate);
     app.run();
 
     Ok(())

--- a/examples/lua/documentation_gen.rs
+++ b/examples/lua/documentation_gen.rs
@@ -98,7 +98,7 @@ fn main() -> std::io::Result<()> {
     app.add_plugins(DefaultPlugins)
         .add_plugin(ScriptingPlugin)
         // add the providers and script host
-        .add_script_host::<LuaScriptHost<MyLuaArg>, _>(CoreStage::PostUpdate)
+        .add_script_host_to_base_set::<LuaScriptHost<MyLuaArg>, _>(CoreSet::PostUpdate)
         .add_api_provider::<LuaScriptHost<MyLuaArg>>(Box::new(LuaAPIProvider))
         .add_api_provider::<LuaScriptHost<MyLuaArg>>(Box::new(LuaBevyAPIProvider))
         // this needs to be placed after any `add_api_provider` and `add_script_host` calls
@@ -107,7 +107,7 @@ fn main() -> std::io::Result<()> {
         // declaration files, use the teal vscode extension to explore the type hints!
         // Note: This is a noop in optimized builds unless the `doc_always` feature is enabled!
         .update_documentation::<LuaScriptHost<MyLuaArg>>()
-        .add_script_handler_stage::<LuaScriptHost<MyLuaArg>, _, 0, 0>(CoreStage::PostUpdate);
+        .add_script_handler_to_base_set::<LuaScriptHost<MyLuaArg>, _, 0, 0>(CoreSet::PostUpdate);
 
     // app.run(); no need, documentation gets generated before the app even starts
 

--- a/examples/lua/event_recipients.rs
+++ b/examples/lua/event_recipients.rs
@@ -94,7 +94,7 @@ fn do_update(mut w: PriorityEventWriter<LuaEvent<MyLuaArg>>) {
         ),
     ];
 
-    // fire random event, for any stages
+    // fire random event, for any of the system sets
     fire_random_event(&mut w, &all_events);
 }
 

--- a/examples/lua/event_recipients.rs
+++ b/examples/lua/event_recipients.rs
@@ -126,8 +126,8 @@ fn main() -> std::io::Result<()> {
         // the script with id 0
         // or the script with id 1
         .add_system(do_update)
-        .add_script_handler_stage::<LuaScriptHost<MyLuaArg>, _, 0, 0>(CoreStage::PostUpdate)
-        .add_script_host::<LuaScriptHost<MyLuaArg>, _>(CoreStage::PostUpdate)
+        .add_script_handler_to_base_set::<LuaScriptHost<MyLuaArg>, _, 0, 0>(CoreSet::PostUpdate)
+        .add_script_host_to_base_set::<LuaScriptHost<MyLuaArg>, _>(CoreSet::PostUpdate)
         .add_api_provider::<LuaScriptHost<MyLuaArg>>(Box::new(LuaAPIProvider));
     app.run();
 

--- a/examples/lua/event_recipients.rs
+++ b/examples/lua/event_recipients.rs
@@ -107,7 +107,6 @@ fn load_our_scripts(server: Res<AssetServer>, mut commands: Commands) {
     let path = "scripts/event_recipients.lua";
     let handle = server.load::<LuaFile, &str>(path);
     let scripts = (0..2)
-        .into_iter()
         .map(|_| Script::<LuaFile>::new(path.to_string(), handle.clone()))
         .collect();
 

--- a/examples/lua/game_of_life.rs
+++ b/examples/lua/game_of_life.rs
@@ -210,7 +210,7 @@ pub fn send_init(mut events: PriorityEventWriter<LuaEvent<()>>) {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, SystemSet)]
-pub enum LifeStages {
+pub enum LifeSystemSets {
     Scripts,
 }
 
@@ -243,13 +243,13 @@ fn main() -> std::io::Result<()> {
                 .in_schedule(CoreSchedule::FixedUpdate),
         )
         .configure_set(
-            LifeStages::Scripts
+            LifeSystemSets::Scripts
                 .after(CoreSet::UpdateFlush)
                 .before(CoreSet::PostUpdate),
         )
         .add_system(
             script_event_handler::<LuaScriptHost<()>, 0, 1>
-                .in_set(LifeStages::Scripts)
+                .in_set(LifeSystemSets::Scripts)
                 .in_schedule(CoreSchedule::FixedUpdate),
         )
         .add_script_host_to_base_set::<LuaScriptHost<()>, _>(CoreSet::PostUpdate)

--- a/examples/lua/game_of_life.rs
+++ b/examples/lua/game_of_life.rs
@@ -8,8 +8,7 @@ use bevy::{
         render_resource::{Extent3d, TextureDimension, TextureFormat},
         texture::ImageSampler,
     },
-    time::FixedTimestep,
-    window::WindowResized,
+    window::{PrimaryWindow, WindowResized},
 };
 
 use bevy_mod_scripting::prelude::*;
@@ -138,15 +137,14 @@ pub fn sync_window_size(
     mut resize_event: EventReader<WindowResized>,
     mut settings: ResMut<Settings>,
     mut query: Query<&mut Sprite, With<LifeState>>,
-    windows: Res<Windows>,
+    primary_windows: Query<(&Window, With<PrimaryWindow>)>,
 ) {
-    if resize_event
+    if let Some(e) = resize_event
         .iter()
-        .filter(|w| w.id.is_primary())
+        .filter(|e| primary_windows.get(e.window).is_ok())
         .last()
-        .is_some()
     {
-        let primary_window = windows.get_primary().unwrap();
+        let (primary_window, _) = primary_windows.get(e.window).unwrap();
         settings.display_grid_dimensions = (
             primary_window.physical_width(),
             primary_window.physical_height(),
@@ -211,51 +209,50 @@ pub fn send_init(mut events: PriorityEventWriter<LuaEvent<()>>) {
     )
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Hash, SystemSet)]
 pub enum LifeStages {
     Scripts,
 }
 
-impl StageLabel for LifeStages {
-    fn as_str(&self) -> &'static str {
-        match self {
-            LifeStages::Scripts => "Scripts",
-        }
-    }
-}
-
 /// how often to step the simulation
-const UPDATE_FREQUENCY: f64 = 1.0 / 20.0;
+const UPDATE_FREQUENCY: f32 = 1.0 / 20.0;
 
 fn main() -> std::io::Result<()> {
     let mut app = App::new();
 
     app.add_plugins(DefaultPlugins)
+        .insert_resource(FixedTime::new_from_secs(UPDATE_FREQUENCY))
         .add_plugin(LogDiagnosticsPlugin::default())
         .add_plugin(FrameTimeDiagnosticsPlugin::default())
         .add_plugin(ScriptingPlugin)
         .init_resource::<Settings>()
         .add_startup_system(setup)
         .add_startup_system(send_init)
-        .add_system(sync_window_size.before(update_rendered_state))
+        .add_system(sync_window_size)
         .add_startup_system(|asset_server: ResMut<AssetServer>| {
             asset_server.asset_io().watch_for_changes().unwrap()
         })
-        .add_system_set(
-            SystemSet::new()
-                .with_run_criteria(FixedTimestep::step(UPDATE_FREQUENCY))
-                .with_system(update_rendered_state)
-                .with_system(send_on_update),
+        .add_system(
+            update_rendered_state
+                .after(sync_window_size)
+                .in_schedule(CoreSchedule::FixedUpdate),
         )
-        .add_stage_after(
-            CoreStage::Update,
-            LifeStages::Scripts,
-            SystemStage::single_threaded(),
+        .add_system(
+            send_on_update
+                .after(update_rendered_state)
+                .in_schedule(CoreSchedule::FixedUpdate),
         )
-        .add_script_handler_stage_with_criteria::<LuaScriptHost<()>, _, _, _, 0, 1>(
-            LifeStages::Scripts,
-            FixedTimestep::step(UPDATE_FREQUENCY),
+        .configure_set(
+            LifeStages::Scripts
+                .after(CoreSet::UpdateFlush)
+                .before(CoreSet::PostUpdate),
         )
-        .add_script_host::<LuaScriptHost<()>, _>(CoreStage::PostUpdate)
+        .add_system(
+            script_event_handler::<LuaScriptHost<()>, 0, 1>
+                .in_set(LifeStages::Scripts)
+                .in_schedule(CoreSchedule::FixedUpdate),
+        )
+        .add_script_host_to_base_set::<LuaScriptHost<()>, _>(CoreSet::PostUpdate)
         .add_api_provider::<LuaScriptHost<()>>(Box::new(LuaBevyAPIProvider))
         .add_api_provider::<LuaScriptHost<()>>(Box::new(LifeAPI))
         .update_documentation::<LuaScriptHost<()>>();

--- a/examples/rhai/bevy_api.rs
+++ b/examples/rhai/bevy_api.rs
@@ -66,8 +66,8 @@ fn main() -> std::io::Result<()> {
         .register_foreign_rhai_type::<Option<Vec<bool>>>()
         // note the implementation for Option is there, but we must register `LuaProxyable` for it
         .init_resource::<MyResource>()
-        // this stage handles addition and removal of script contexts, we can safely use `CoreStage::PostUpdate`
-        .add_script_host::<RhaiScriptHost<()>, _>(CoreStage::PostUpdate)
+        // this system set handles addition and removal of script contexts, we can safely use `CoreSet::PostUpdate`
+        .add_script_host_to_base_set::<RhaiScriptHost<()>, _>(CoreSet::PostUpdate)
         .add_api_provider::<RhaiScriptHost<()>>(Box::new(RhaiBevyAPIProvider))
         .add_api_provider::<RhaiScriptHost<()>>(Box::new(MyAPIProvider))
         .add_system(|world: &mut World| {
@@ -122,9 +122,13 @@ fn main() -> std::io::Result<()> {
                             my_component.bool_option = true;
                             print(my_component.bool_option);
                             
+                            print("----");
+
                             for e in my_component.vec_of_option_bools {
                                 print(`elem: ${e}`)
                             }
+                            
+                            print("----");
 
                             my_component.vec_of_option_bools = [true,false,true];
                             my_component.vec_of_option_bools[0] = false;

--- a/examples/rhai/console_integration.rs
+++ b/examples/rhai/console_integration.rs
@@ -2,6 +2,7 @@ use bevy::{ecs::event::Events, prelude::*};
 use bevy_console::{AddConsoleCommand, ConsoleCommand, ConsolePlugin, PrintConsoleLine};
 use bevy_mod_scripting::prelude::*;
 use bevy_script_api::common::bevy::ScriptWorld;
+use clap::Parser;
 /// custom Rhai API, world is provided as a usize (by the script this time), since
 /// Rhai does not allow global/local variable access from a callback
 #[derive(Default)]
@@ -26,7 +27,7 @@ impl APIProvider for RhaiAPI {
                 let mut world = world.write();
 
                 let mut events: Mut<Events<PrintConsoleLine>> = world.get_resource_mut().unwrap();
-                events.send(PrintConsoleLine { line: msg });
+                events.send(PrintConsoleLine { line: msg.into() });
             },
         );
 
@@ -45,7 +46,7 @@ impl APIProvider for RhaiAPI {
 }
 
 // sends updates to script host which are then handled by the scripts
-// in the designated stage
+// in the designated system sets
 pub fn trigger_on_update_rhai(mut w: PriorityEventWriter<RhaiEvent<()>>) {
     let event = RhaiEvent {
         hook_name: "on_update".to_string(),
@@ -62,7 +63,7 @@ pub fn forward_script_err_to_console(
 ) {
     for e in r.iter() {
         w.send(PrintConsoleLine {
-            line: format!("ERROR:{}", e.error),
+            line: format!("ERROR:{}", e.error).into(),
         });
     }
 }
@@ -70,8 +71,8 @@ pub fn forward_script_err_to_console(
 // we use bevy-debug-console to demonstrate how this can fit in in the runtime of a game
 // note that using just the entity id instead of the full Entity has issues,
 // but since we aren't despawning/spawning entities this works in our case
-#[derive(ConsoleCommand)]
-#[console_command(name = "run_script")]
+#[derive(Parser, ConsoleCommand)]
+#[command(name = "run_script")]
 ///Runs a Lua script from the `assets/scripts` directory
 pub struct RunScriptCmd {
     /// the relative path to the script, e.g.: `/hello.lua` for a script located in `assets/scripts/hello.lua`
@@ -142,8 +143,8 @@ pub fn delete_script_cmd(
     }
 }
 
-#[derive(ConsoleCommand)]
-#[console_command(name = "delete_script")]
+#[derive(Parser, ConsoleCommand)]
+#[command(name = "delete_script")]
 ///Runs a Lua script from the `assets/scripts` directory
 pub struct DeleteScriptCmd {
     ///the name of the script
@@ -163,10 +164,10 @@ fn main() -> std::io::Result<()> {
         .add_console_command::<RunScriptCmd, _>(run_script_cmd)
         .add_console_command::<DeleteScriptCmd, _>(delete_script_cmd)
         // choose and register the script hosts you want to use
-        .add_script_host::<RhaiScriptHost<()>, _>(CoreStage::PostUpdate)
+        .add_script_host_to_base_set::<RhaiScriptHost<()>, _>(CoreSet::PostUpdate)
         .add_api_provider::<RhaiScriptHost<()>>(Box::new(RhaiAPI))
         .add_api_provider::<RhaiScriptHost<()>>(Box::new(RhaiBevyAPIProvider))
-        .add_script_handler_stage::<RhaiScriptHost<()>, _, 0, 0>(CoreStage::PostUpdate)
+        .add_script_handler_to_base_set::<RhaiScriptHost<()>, _, 0, 0>(CoreSet::PostUpdate)
         // add your systems
         .add_system(trigger_on_update_rhai)
         .add_system(forward_script_err_to_console);

--- a/examples/rhai/game_of_life.rs
+++ b/examples/rhai/game_of_life.rs
@@ -200,12 +200,13 @@ pub enum LifeSystemSets {
 }
 
 /// how often to step the simulation
-const UPDATE_FREQUENCY: f64 = 1.0 / 30.0;
+const UPDATE_FREQUENCY: f32 = 1.0 / 30.0;
 
 fn main() -> std::io::Result<()> {
     let mut app = App::new();
 
     app.add_plugins(DefaultPlugins)
+        .insert_resource(FixedTime::new_from_secs(UPDATE_FREQUENCY))
         .add_plugin(LogDiagnosticsPlugin::default())
         .add_plugin(FrameTimeDiagnosticsPlugin::default())
         .add_plugin(ScriptingPlugin)

--- a/examples/rhai/game_of_life.rs
+++ b/examples/rhai/game_of_life.rs
@@ -6,8 +6,7 @@ use bevy::{
         render_resource::{Extent3d, TextureDimension, TextureFormat},
         texture::ImageSampler,
     },
-    time::FixedTimestep,
-    window::WindowResized,
+    window::{PrimaryWindow, WindowResized},
 };
 
 use bevy_mod_scripting::prelude::*;
@@ -123,15 +122,14 @@ pub fn sync_window_size(
     mut resize_event: EventReader<WindowResized>,
     mut settings: ResMut<Settings>,
     mut query: Query<&mut Sprite, With<LifeState>>,
-    windows: Res<Windows>,
+    primary_windows: Query<(&Window, With<PrimaryWindow>)>,
 ) {
-    if resize_event
+    if let Some(e) = resize_event
         .iter()
-        .filter(|w| w.id.is_primary())
+        .filter(|e| primary_windows.get(e.window).is_ok())
         .last()
-        .is_some()
     {
-        let primary_window = windows.get_primary().unwrap();
+        let (primary_window, _) = primary_windows.get(e.window).unwrap();
         settings.display_grid_dimensions = (
             primary_window.physical_width(),
             primary_window.physical_height(),
@@ -196,8 +194,8 @@ pub fn send_init(mut events: PriorityEventWriter<RhaiEvent<()>>) {
     )
 }
 
-#[derive(SystemSet)]
-pub enum LifeStages {
+#[derive(Debug, Clone, PartialEq, Eq, Hash, SystemSet)]
+pub enum LifeSystemSets {
     Scripts,
 }
 
@@ -214,26 +212,26 @@ fn main() -> std::io::Result<()> {
         .init_resource::<Settings>()
         .add_startup_system(setup)
         .add_startup_system(send_init)
-        .add_system(sync_window_size.before(update_rendered_state))
         .add_startup_system(|asset_server: ResMut<AssetServer>| {
             asset_server.asset_io().watch_for_changes().unwrap()
         })
-        .add_system_set(
-            SystemSet::new()
-                .with_run_criteria(FixedTimestep::step(UPDATE_FREQUENCY))
-                .with_system(update_rendered_state)
-                .with_system(send_on_update),
+        .add_system(sync_window_size)
+        .add_systems(
+            (update_rendered_state, send_on_update)
+                .chain()
+                .in_schedule(CoreSchedule::FixedUpdate),
         )
-        .add_stage_after(
-            CoreStage::Update,
-            LifeStages::Scripts,
-            SystemStage::single_threaded(),
+        .configure_set(
+            LifeSystemSets::Scripts
+                .after(CoreSet::UpdateFlush)
+                .before(CoreSet::PostUpdate),
         )
-        .add_script_handler_stage_with_criteria::<RhaiScriptHost<()>, _, _, _, 0, 1>(
-            LifeStages::Scripts,
-            FixedTimestep::step(UPDATE_FREQUENCY),
+        .add_system(
+            script_event_handler::<RhaiScriptHost<()>, 0, 1>
+                .in_set(LifeSystemSets::Scripts)
+                .in_schedule(CoreSchedule::FixedUpdate),
         )
-        .add_script_host::<RhaiScriptHost<()>, _>(CoreStage::PostUpdate)
+        .add_script_host_to_base_set::<RhaiScriptHost<()>, _>(CoreSet::PostUpdate)
         .add_api_provider::<RhaiScriptHost<()>>(Box::new(RhaiBevyAPIProvider))
         .add_api_provider::<RhaiScriptHost<()>>(Box::new(LifeAPI))
         .update_documentation::<RhaiScriptHost<()>>();

--- a/examples/rhai/game_of_life.rs
+++ b/examples/rhai/game_of_life.rs
@@ -196,16 +196,9 @@ pub fn send_init(mut events: PriorityEventWriter<RhaiEvent<()>>) {
     )
 }
 
+#[derive(SystemSet)]
 pub enum LifeStages {
     Scripts,
-}
-
-impl StageLabel for LifeStages {
-    fn as_str(&self) -> &'static str {
-        match self {
-            LifeStages::Scripts => "Scripts",
-        }
-    }
 }
 
 /// how often to step the simulation

--- a/examples/wrappers.rs
+++ b/examples/wrappers.rs
@@ -85,7 +85,7 @@ fn main() -> std::io::Result<()> {
 
     app.add_plugins(DefaultPlugins)
         .add_plugin(ScriptingPlugin)
-        .add_script_host::<LuaScriptHost<LuaMyThing>, _>(CoreStage::PostUpdate)
+        .add_script_host_to_base_set::<LuaScriptHost<LuaMyThing>, _>(CoreSet::PostUpdate)
         .register_type::<MyThing>()
         .init_resource::<MyThing>()
         .add_system(|world: &mut World| {

--- a/languages/bevy_mod_scripting_lua/Cargo.toml
+++ b/languages/bevy_mod_scripting_lua/Cargo.toml
@@ -40,7 +40,7 @@ name="bevy_mod_scripting_lua"
 path="src/lib.rs"
 
 [dependencies]
-bevy= { version = "0.9", default-features = false}
+bevy= { version = "0.10", default-features = false}
 bevy_mod_scripting_core = {path="../../bevy_mod_scripting_core", version = "0.2.2" }
 tealr = { version = "=0.9.0-alpha4", git = "https://github.com/awestlake87/tealr", rev = "120ab2da424fbfaaf1a96f77c60072707399a4ba", features=["mlua_vendored","mlua_send"]}
 parking_lot = "0.12.1"

--- a/languages/bevy_mod_scripting_lua/Cargo.toml
+++ b/languages/bevy_mod_scripting_lua/Cargo.toml
@@ -40,7 +40,7 @@ name="bevy_mod_scripting_lua"
 path="src/lib.rs"
 
 [dependencies]
-bevy= { version = "0.10", default-features = false}
+bevy= { version = "0.10.1", default-features = false}
 bevy_mod_scripting_core = {path="../../bevy_mod_scripting_core", version = "0.2.2" }
 tealr = { version = "=0.9.0-alpha4", git = "https://github.com/awestlake87/tealr", rev = "120ab2da424fbfaaf1a96f77c60072707399a4ba", features=["mlua_vendored","mlua_send"]}
 parking_lot = "0.12.1"

--- a/languages/bevy_mod_scripting_lua/Cargo.toml
+++ b/languages/bevy_mod_scripting_lua/Cargo.toml
@@ -42,7 +42,7 @@ path="src/lib.rs"
 [dependencies]
 bevy= { version = "0.9", default-features = false}
 bevy_mod_scripting_core = {path="../../bevy_mod_scripting_core", version = "0.2.2" }
-tealr = { version = "=0.9.0-alpha4", features=["mlua_vendored","mlua_send"]}
+tealr = { version = "=0.9.0-alpha4", git = "https://github.com/awestlake87/tealr", rev = "120ab2da424fbfaaf1a96f77c60072707399a4ba", features=["mlua_vendored","mlua_send"]}
 parking_lot = "0.12.1"
 serde_json = "1.0.81"
 serde = { version = "1", features = ["derive"] }

--- a/languages/bevy_mod_scripting_lua/src/lib.rs
+++ b/languages/bevy_mod_scripting_lua/src/lib.rs
@@ -2,7 +2,10 @@ use crate::{
     assets::{LuaFile, LuaLoader},
     docs::LuaDocFragment,
 };
-use bevy::prelude::*;
+use bevy::{
+    ecs::schedule::{BaseSystemSet, FreeSystemSet},
+    prelude::*,
+};
 use bevy_mod_scripting_core::{prelude::*, systems::*, world::WorldPointer};
 
 use std::fmt;
@@ -78,7 +81,7 @@ impl<A: LuaArg> ScriptHost for LuaScriptHost<A> {
     type ScriptAsset = LuaFile;
     type DocTarget = LuaDocFragment;
 
-    fn register_with_app(app: &mut App, stage: impl StageLabel) {
+    fn register_with_app_in_set(app: &mut App, set: impl FreeSystemSet + Clone) {
         app.add_priority_event::<Self::ScriptEvent>()
             .add_asset::<LuaFile>()
             .init_asset_loader::<LuaLoader>()
@@ -88,20 +91,44 @@ impl<A: LuaArg> ScriptHost for LuaScriptHost<A> {
             .register_type::<ScriptCollection<Self::ScriptAsset>>()
             .register_type::<Script<Self::ScriptAsset>>()
             .register_type::<Handle<LuaFile>>()
-            .add_system_set_to_stage(
-                stage,
-                SystemSet::new()
-                    // handle script insertions removal first
-                    // then update their contexts later on script asset changes
-                    .with_system(
-                        script_add_synchronizer::<Self>.before(script_remove_synchronizer::<Self>),
-                    )
-                    .with_system(
-                        script_remove_synchronizer::<Self>
-                            .before(script_hot_reload_handler::<Self>),
-                    )
-                    .with_system(script_hot_reload_handler::<Self>),
-            );
+            // handle script insertions removal first
+            // then update their contexts later on script asset changes
+            .add_system(
+                script_add_synchronizer::<Self>
+                    .before(script_remove_synchronizer::<Self>)
+                    .in_set(set.clone()),
+            )
+            .add_system(
+                script_remove_synchronizer::<Self>
+                    .before(script_hot_reload_handler::<Self>)
+                    .in_set(set.clone()),
+            )
+            .add_system(script_hot_reload_handler::<Self>.in_set(set));
+    }
+
+    fn register_with_app_in_base_set(app: &mut App, set: impl BaseSystemSet + Clone) {
+        app.add_priority_event::<Self::ScriptEvent>()
+            .add_asset::<LuaFile>()
+            .init_asset_loader::<LuaLoader>()
+            .init_resource::<CachedScriptState<Self>>()
+            .init_resource::<ScriptContexts<Self::ScriptContext>>()
+            .init_resource::<APIProviders<Self>>()
+            .register_type::<ScriptCollection<Self::ScriptAsset>>()
+            .register_type::<Script<Self::ScriptAsset>>()
+            .register_type::<Handle<LuaFile>>()
+            // handle script insertions removal first
+            // then update their contexts later on script asset changes
+            .add_system(
+                script_add_synchronizer::<Self>
+                    .before(script_remove_synchronizer::<Self>)
+                    .in_base_set(set.clone()),
+            )
+            .add_system(
+                script_remove_synchronizer::<Self>
+                    .before(script_hot_reload_handler::<Self>)
+                    .in_base_set(set.clone()),
+            )
+            .add_system(script_hot_reload_handler::<Self>.in_base_set(set));
     }
 
     fn load_script(

--- a/languages/bevy_mod_scripting_lua_derive/src/derive_flags/auto_methods.rs
+++ b/languages/bevy_mod_scripting_lua_derive/src/derive_flags/auto_methods.rs
@@ -9,7 +9,7 @@ use syn::{parse_quote_spanned, punctuated::Punctuated, spanned::Spanned, LitInt,
 
 use crate::lua_method::LuaMethod;
 
-pub(crate) fn make_methods<'a>(flag: &DeriveFlag, new_type: &'a Newtype, out: &mut Vec<LuaMethod>) {
+pub(crate) fn make_methods(flag: &DeriveFlag, new_type: &Newtype, out: &mut Vec<LuaMethod>) {
     let wrapped_type = &new_type.args.base_type_ident;
 
     let methods = match flag {

--- a/languages/bevy_mod_scripting_lua_derive/src/derive_flags/bin_ops.rs
+++ b/languages/bevy_mod_scripting_lua_derive/src/derive_flags/bin_ops.rs
@@ -11,10 +11,10 @@ use syn::{parse_quote_spanned, spanned::Spanned, Token};
 
 use crate::{implementor::LuaImplementor, lua_method::LuaMethod};
 
-pub(crate) fn make_bin_ops<'a>(
+pub(crate) fn make_bin_ops(
     implementor: &mut LuaImplementor,
     flag: &DeriveFlag,
-    new_type: &'a Newtype,
+    new_type: &Newtype,
     out: &mut Vec<LuaMethod>,
 ) -> Result<(), syn::Error> {
     let newtype_name = &new_type.args.wrapper_type;

--- a/languages/bevy_mod_scripting_lua_derive/src/derive_flags/fields.rs
+++ b/languages/bevy_mod_scripting_lua_derive/src/derive_flags/fields.rs
@@ -4,9 +4,9 @@ use syn::{parse_quote_spanned, spanned::Spanned};
 
 use crate::lua_method::LuaMethod;
 
-pub(crate) fn make_fields<'a>(
+pub(crate) fn make_fields(
     flag: &DeriveFlag,
-    new_type: &'a Newtype,
+    new_type: &Newtype,
     out: &mut Vec<LuaMethod>,
 ) -> Result<(), syn::Error> {
     let newtype_name = &new_type.args.wrapper_type;

--- a/languages/bevy_mod_scripting_lua_derive/src/derive_flags/unary_ops.rs
+++ b/languages/bevy_mod_scripting_lua_derive/src/derive_flags/unary_ops.rs
@@ -4,9 +4,9 @@ use syn::{parse_quote, parse_quote_spanned, spanned::Spanned};
 
 use crate::lua_method::LuaMethod;
 
-pub(crate) fn make_unary_ops<'a>(
+pub(crate) fn make_unary_ops(
     flag: &DeriveFlag,
-    new_type: &'a Newtype,
+    new_type: &Newtype,
     out: &mut Vec<LuaMethod>,
 ) -> Result<(), syn::Error> {
     let newtype = &new_type.args.wrapper_type;

--- a/languages/bevy_mod_scripting_rhai/Cargo.toml
+++ b/languages/bevy_mod_scripting_rhai/Cargo.toml
@@ -22,6 +22,6 @@ name="bevy_mod_scripting_rhai"
 path="src/lib.rs"
 
 [dependencies]
-bevy= { version = "0.9", default-features = false}
+bevy= { version = "0.10", default-features = false}
 rhai = { version = "1.8.0", features = ["sync"] }
 bevy_mod_scripting_core = {path="../../bevy_mod_scripting_core", version = "0.2.2" }

--- a/languages/bevy_mod_scripting_rhai/Cargo.toml
+++ b/languages/bevy_mod_scripting_rhai/Cargo.toml
@@ -22,6 +22,6 @@ name="bevy_mod_scripting_rhai"
 path="src/lib.rs"
 
 [dependencies]
-bevy= { version = "0.10", default-features = false}
+bevy= { version = "0.10.1", default-features = false}
 rhai = { version = "1.8.0", features = ["sync"] }
 bevy_mod_scripting_core = {path="../../bevy_mod_scripting_core", version = "0.2.2" }

--- a/languages/bevy_mod_scripting_rhai/src/lib.rs
+++ b/languages/bevy_mod_scripting_rhai/src/lib.rs
@@ -69,7 +69,7 @@ impl<A: FuncArgs + Send + Clone + Sync + 'static> ScriptHost for RhaiScriptHost<
     type APITarget = Engine;
     type DocTarget = RhaiDocFragment;
 
-    fn register_with_app(app: &mut bevy::prelude::App, stage: impl bevy::prelude::StageLabel) {
+    fn register_with_app(app: &mut bevy::prelude::App, set: impl bevy::prelude::SystemSet) {
         app.add_priority_event::<Self::ScriptEvent>()
             .add_asset::<RhaiFile>()
             .init_asset_loader::<RhaiLoader>()

--- a/makefile
+++ b/makefile
@@ -58,22 +58,22 @@ generate_api:
 	rustfmt ./bevy_script_api/src/generated.rs
 
 make_json_files:
-	rustup run nightly-2022-12-18 cargo rustdoc -p bevy_asset@0.9.1  --  -Zunstable-options --output-format json && \
-	rustup run nightly-2022-12-18 cargo rustdoc -p bevy_ecs@0.9.1 --  -Zunstable-options --output-format json && \
-	rustup run nightly-2022-12-18 cargo rustdoc -p bevy_pbr@0.9.1 --  -Zunstable-options --output-format json && \
-	rustup run nightly-2022-12-18 cargo rustdoc -p bevy_render@0.9.1 --  -Zunstable-options --output-format json && \
-	rustup run nightly-2022-12-18 cargo rustdoc -p bevy_math@0.9.1 --  -Zunstable-options --output-format json && \
-	rustup run nightly-2022-12-18 cargo rustdoc -p bevy_transform@0.9.1 --  -Zunstable-options --output-format json && \
-	rustup run nightly-2022-12-18 cargo rustdoc -p bevy_sprite@0.9.1 --  -Zunstable-options --output-format json && \
-	rustup run nightly-2022-12-18 cargo rustdoc -p bevy_ui@0.9.1 --  -Zunstable-options --output-format json && \
-	rustup run nightly-2022-12-18 cargo rustdoc -p bevy_animation@0.9.1 --  -Zunstable-options --output-format json && \
-	rustup run nightly-2022-12-18 cargo rustdoc -p bevy_core@0.9.1 --  -Zunstable-options --output-format json && \
-	rustup run nightly-2022-12-18 cargo rustdoc -p bevy_core_pipeline@0.9.1 --  -Zunstable-options --output-format json && \
-	rustup run nightly-2022-12-18 cargo rustdoc -p bevy_gltf@0.9.1 --  -Zunstable-options --output-format json && \
-	rustup run nightly-2022-12-18 cargo rustdoc -p bevy_hierarchy@0.9.1 --  -Zunstable-options --output-format json && \
-	rustup run nightly-2022-12-18 cargo rustdoc -p bevy_text@0.9.1 --  -Zunstable-options --output-format json && \
-	rustup run nightly-2022-12-18 cargo rustdoc -p bevy_time@0.9.1 --  -Zunstable-options --output-format json && \
-	rustup run nightly-2022-12-18 cargo rustdoc -p bevy_utils@0.9.1 --  -Zunstable-options --output-format json && \
-	rustup run nightly-2022-12-18 cargo rustdoc -p bevy_reflect@0.9.1 --  -Zunstable-options --output-format json && \
-	rustup run nightly-2022-12-18 cargo rustdoc -p glam@0.22.0 --  -Zunstable-options --output-format json && \
-	rustup run nightly-2022-12-18 cargo rustdoc -p bevy@0.9.1 --  -Zunstable-options --output-format json 
+	rustup run nightly-2022-12-18 cargo rustdoc -p bevy_asset@0.10.0  --  -Zunstable-options --output-format json && \
+	rustup run nightly-2022-12-18 cargo rustdoc -p bevy_ecs@0.10.0 --  -Zunstable-options --output-format json && \
+	rustup run nightly-2022-12-18 cargo rustdoc -p bevy_pbr@0.10.0 --  -Zunstable-options --output-format json && \
+	rustup run nightly-2022-12-18 cargo rustdoc -p bevy_render@0.10.0 --  -Zunstable-options --output-format json && \
+	rustup run nightly-2022-12-18 cargo rustdoc -p bevy_math@0.10.0 --  -Zunstable-options --output-format json && \
+	rustup run nightly-2022-12-18 cargo rustdoc -p bevy_transform@0.10.0 --  -Zunstable-options --output-format json && \
+	rustup run nightly-2022-12-18 cargo rustdoc -p bevy_sprite@0.10.0 --  -Zunstable-options --output-format json && \
+	rustup run nightly-2022-12-18 cargo rustdoc -p bevy_ui@0.10.0 --  -Zunstable-options --output-format json && \
+	rustup run nightly-2022-12-18 cargo rustdoc -p bevy_animation@0.10.0 --  -Zunstable-options --output-format json && \
+	rustup run nightly-2022-12-18 cargo rustdoc -p bevy_core@0.10.0 --  -Zunstable-options --output-format json && \
+	rustup run nightly-2022-12-18 cargo rustdoc -p bevy_core_pipeline@0.10.0 --  -Zunstable-options --output-format json && \
+	rustup run nightly-2022-12-18 cargo rustdoc -p bevy_gltf@0.10.0 --  -Zunstable-options --output-format json && \
+	rustup run nightly-2022-12-18 cargo rustdoc -p bevy_hierarchy@0.10.0 --  -Zunstable-options --output-format json && \
+	rustup run nightly-2022-12-18 cargo rustdoc -p bevy_text@0.10.0 --  -Zunstable-options --output-format json && \
+	rustup run nightly-2022-12-18 cargo rustdoc -p bevy_time@0.10.0 --  -Zunstable-options --output-format json && \
+	rustup run nightly-2022-12-18 cargo rustdoc -p bevy_utils@0.10.0 --  -Zunstable-options --output-format json && \
+	rustup run nightly-2022-12-18 cargo rustdoc -p bevy_reflect@0.10.0 --  -Zunstable-options --output-format json && \
+	rustup run nightly-2022-12-18 cargo rustdoc -p glam@0.23.0 --  -Zunstable-options --output-format json && \
+	rustup run nightly-2022-12-18 cargo rustdoc -p bevy@0.10.0 --  -Zunstable-options --output-format json 

--- a/makefile
+++ b/makefile
@@ -58,22 +58,22 @@ generate_api:
 	rustfmt ./bevy_script_api/src/generated.rs
 
 make_json_files:
-	rustup run nightly-2022-12-18 cargo rustdoc -p bevy_asset@0.10.0  --  -Zunstable-options --output-format json && \
-	rustup run nightly-2022-12-18 cargo rustdoc -p bevy_ecs@0.10.0 --  -Zunstable-options --output-format json && \
-	rustup run nightly-2022-12-18 cargo rustdoc -p bevy_pbr@0.10.0 --  -Zunstable-options --output-format json && \
-	rustup run nightly-2022-12-18 cargo rustdoc -p bevy_render@0.10.0 --  -Zunstable-options --output-format json && \
-	rustup run nightly-2022-12-18 cargo rustdoc -p bevy_math@0.10.0 --  -Zunstable-options --output-format json && \
-	rustup run nightly-2022-12-18 cargo rustdoc -p bevy_transform@0.10.0 --  -Zunstable-options --output-format json && \
-	rustup run nightly-2022-12-18 cargo rustdoc -p bevy_sprite@0.10.0 --  -Zunstable-options --output-format json && \
-	rustup run nightly-2022-12-18 cargo rustdoc -p bevy_ui@0.10.0 --  -Zunstable-options --output-format json && \
-	rustup run nightly-2022-12-18 cargo rustdoc -p bevy_animation@0.10.0 --  -Zunstable-options --output-format json && \
-	rustup run nightly-2022-12-18 cargo rustdoc -p bevy_core@0.10.0 --  -Zunstable-options --output-format json && \
-	rustup run nightly-2022-12-18 cargo rustdoc -p bevy_core_pipeline@0.10.0 --  -Zunstable-options --output-format json && \
-	rustup run nightly-2022-12-18 cargo rustdoc -p bevy_gltf@0.10.0 --  -Zunstable-options --output-format json && \
-	rustup run nightly-2022-12-18 cargo rustdoc -p bevy_hierarchy@0.10.0 --  -Zunstable-options --output-format json && \
-	rustup run nightly-2022-12-18 cargo rustdoc -p bevy_text@0.10.0 --  -Zunstable-options --output-format json && \
-	rustup run nightly-2022-12-18 cargo rustdoc -p bevy_time@0.10.0 --  -Zunstable-options --output-format json && \
-	rustup run nightly-2022-12-18 cargo rustdoc -p bevy_utils@0.10.0 --  -Zunstable-options --output-format json && \
-	rustup run nightly-2022-12-18 cargo rustdoc -p bevy_reflect@0.10.0 --  -Zunstable-options --output-format json && \
+	rustup run nightly-2022-12-18 cargo rustdoc -p bevy_asset@0.10.1  --  -Zunstable-options --output-format json && \
+	rustup run nightly-2022-12-18 cargo rustdoc -p bevy_ecs@0.10.1 --  -Zunstable-options --output-format json && \
+	rustup run nightly-2022-12-18 cargo rustdoc -p bevy_pbr@0.10.1 --  -Zunstable-options --output-format json && \
+	rustup run nightly-2022-12-18 cargo rustdoc -p bevy_render@0.10.1 --  -Zunstable-options --output-format json && \
+	rustup run nightly-2022-12-18 cargo rustdoc -p bevy_math@0.10.1 --  -Zunstable-options --output-format json && \
+	rustup run nightly-2022-12-18 cargo rustdoc -p bevy_transform@0.10.1 --  -Zunstable-options --output-format json && \
+	rustup run nightly-2022-12-18 cargo rustdoc -p bevy_sprite@0.10.1 --  -Zunstable-options --output-format json && \
+	rustup run nightly-2022-12-18 cargo rustdoc -p bevy_ui@0.10.1 --  -Zunstable-options --output-format json && \
+	rustup run nightly-2022-12-18 cargo rustdoc -p bevy_animation@0.10.1 --  -Zunstable-options --output-format json && \
+	rustup run nightly-2022-12-18 cargo rustdoc -p bevy_core@0.10.1 --  -Zunstable-options --output-format json && \
+	rustup run nightly-2022-12-18 cargo rustdoc -p bevy_core_pipeline@0.10.1 --  -Zunstable-options --output-format json && \
+	rustup run nightly-2022-12-18 cargo rustdoc -p bevy_gltf@0.10.1 --  -Zunstable-options --output-format json && \
+	rustup run nightly-2022-12-18 cargo rustdoc -p bevy_hierarchy@0.10.1 --  -Zunstable-options --output-format json && \
+	rustup run nightly-2022-12-18 cargo rustdoc -p bevy_text@0.10.1 --  -Zunstable-options --output-format json && \
+	rustup run nightly-2022-12-18 cargo rustdoc -p bevy_time@0.10.1 --  -Zunstable-options --output-format json && \
+	rustup run nightly-2022-12-18 cargo rustdoc -p bevy_utils@0.10.1 --  -Zunstable-options --output-format json && \
+	rustup run nightly-2022-12-18 cargo rustdoc -p bevy_reflect@0.10.1 --  -Zunstable-options --output-format json && \
 	rustup run nightly-2022-12-18 cargo rustdoc -p glam@0.23.0 --  -Zunstable-options --output-format json && \
-	rustup run nightly-2022-12-18 cargo rustdoc -p bevy@0.10.0 --  -Zunstable-options --output-format json 
+	rustup run nightly-2022-12-18 cargo rustdoc -p bevy@0.10.1 --  -Zunstable-options --output-format json 

--- a/makefile
+++ b/makefile
@@ -75,5 +75,5 @@ make_json_files:
 	rustup run nightly-2022-12-18 cargo rustdoc -p bevy_time@0.9.1 --  -Zunstable-options --output-format json && \
 	rustup run nightly-2022-12-18 cargo rustdoc -p bevy_utils@0.9.1 --  -Zunstable-options --output-format json && \
 	rustup run nightly-2022-12-18 cargo rustdoc -p bevy_reflect@0.9.1 --  -Zunstable-options --output-format json && \
-	rustup run nightly-2022-12-18 cargo rustdoc -p glam --  -Zunstable-options --output-format json && \
+	rustup run nightly-2022-12-18 cargo rustdoc -p glam@0.22.0 --  -Zunstable-options --output-format json && \
 	rustup run nightly-2022-12-18 cargo rustdoc -p bevy@0.9.1 --  -Zunstable-options --output-format json 

--- a/readme.md
+++ b/readme.md
@@ -21,7 +21,7 @@ This crate is an attempt to make scripting a possibility with the current state 
 - Rhai integration
 - Customisable script API's
 - Event based hooks (i.e. on_update)
-- Flexible event scheduling (i.e. allow handling events at different stages rather than a single stage based on the event)
+- Flexible event scheduling (i.e. allow handling events at handling stages based on the event)
 - Multiple scripts per entity
 - Multiple instances of the same script on one entity
 - Extensive callback argument type support
@@ -55,8 +55,8 @@ To install:
   - The crate is still in development so I recommended pinning to a git commit
 - Add ScriptingPlugin to your app
 - Add the ScriptHosts you plan on using (`add_script_host`)
-  - Make sure to attach it to a stage running AFTER any systems which may generate modify/create/remove script components
-- Add script handler stages to capture events in the priority range you're expecting (`add_script_handler_stage`)
+  - Make sure to attach it to a system set running AFTER any systems which may generate modify/create/remove script components
+- Add script handlers to capture events in the priority range you're expecting (`add_script_handler_to_set`,`add_script_handler_to_base_set`)
 - Add systems which generate ScriptEvents corresponding to your script host
 - Add systems which add ScriptCollection components to your entities and fill them with scripts
 
@@ -69,15 +69,15 @@ fn main() -> std::io::Result<()> {
         app.add_plugin(ScriptingPlugin)
         .add_plugins(DefaultPlugins)
         // pick and register only the hosts you want to use
-        // use any stage AFTER any systems which add/remove/modify script components
+        // use any system set AFTER any systems which add/remove/modify script components
         // in order for your script updates to propagate in a single frame
         .add_script_host_to_base_set::<RhaiScriptHost<MyRhaiArgStruct>,_>(CoreSet::PostUpdate)
         .add_script_host_to_base_set::<LuaScriptHost<MyLuaArgStruct>,_>(CoreSet::PostUpdate)
 
-        // the handlers should be placed after any stages which produce script events
-        // PostUpdate is okay only if your API doesn't require the core Bevy systems' commands
+        // the handlers should be ran after any systems which produce script events.
+        // The PostUpdate set is okay only if your API doesn't require the core Bevy systems' commands
         // to run beforehand.
-        // Note, this setup assumes a single script handler stage with all events having identical
+        // Note, this setup assumes a single script handler system set with all events having identical
         // priority of zero (see examples for more complex scenarios)
         .add_script_handler_to_base_set::<LuaScriptHost<MyLuaArg>, _, 0, 0>(
             CoreSet::PostUpdate,

--- a/src/documentation/main.rs
+++ b/src/documentation/main.rs
@@ -16,7 +16,7 @@ fn main() {
     match lang.as_str() {
         "lua" => {
             #[cfg(all(feature = "lua", feature = "lua_script_api"))]
-            app.add_script_host::<LuaScriptHost<()>, _>(CoreStage::PostUpdate)
+            app.add_script_host_to_base_set::<LuaScriptHost<()>, _>(CoreSet::PostUpdate)
                 .add_api_provider::<LuaScriptHost<()>>(Box::new(LuaBevyAPIProvider))
                 .update_documentation::<LuaScriptHost<()>>();
 


### PR DESCRIPTION
Bevy has been updated to Bevy 0.10:
- updates this library to make use of new scheduling features and makes it compatible with Bevy 0.10

Credit to @awestlake87 for initial work on this: 
 - https://github.com/awestlake87/bevy_mod_scripting
 - Duplicate of, hence closes https://github.com/makspll/bevy_mod_scripting/pull/46
 - Closes https://github.com/makspll/bevy_mod_scripting/issues/45

Instead of committing directly to said fork I am duplicating the branch on this repo so that people consuming that fork directly don't have to be suddenly forced to change anything. 