### PR TITLE
Enable lua54 feature for docs.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ name = "bevy_mod_scripting"
 path = "src/lib.rs"
 
 [package.metadata."docs.rs"]
-features = ["lua","rhai","lua_script_api","rhai_script_api","teal"]
+features = ["lua","lua54","rhai","lua_script_api","rhai_script_api","teal"]
 
 [package.metadata.release]
 pre-release-replacements = [


### PR DESCRIPTION
Fixes #49

If some other version of lua is desired for docs.rs, then tell me and I'll change it.