### PR TITLE
add new CI step for documentation checking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,4 +97,4 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: doc
-          args: --workspace --features=cargo doc --workspace --features=$(cargo metadata --no-deps | python -c "import sys,json; [print(','.join(x['metadata']['docs.rs']['features'])) for x in json.load(sys.stdin)['packages'] if x['name'] == 'bevy_mod_scripting']")
+          args: --workspace --features=$(cargo metadata --no-deps | python -c "import sys,json; [print(','.join(x['metadata']['docs.rs']['features'])) for x in json.load(sys.stdin)['packages'] if x['name'] == 'bevy_mod_scripting']")

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,10 @@ jobs:
           toolchain: stable
           override: true
       - uses: Swatinem/rust-cache@v2.2.0
+      - name: Find docs.rs features
+        run: echo "DOCS_FEATURES=$(cargo metadata --no-deps | python -c "import sys,json; [print(','.join(x['metadata']['docs.rs']['features'])) for x in json.load(sys.stdin)['packages'] if x['name'] == 'bevy_mod_scripting']")" >> $GITHUB_OUTPUT
+        id: features
       - uses: actions-rs/cargo@v1
         with:
           command: doc
-          args: --workspace --features=$(cargo metadata --no-deps | python -c "import sys,json; [print(','.join(x['metadata']['docs.rs']['features'])) for x in json.load(sys.stdin)['packages'] if x['name'] == 'bevy_mod_scripting']")
+          args: --workspace --features=${{ steps.features.outputs.DOCS_FEATURES }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,5 +96,5 @@ jobs:
       - uses: Swatinem/rust-cache@v2.2.0
       - uses: actions-rs/cargo@v1
         with:
-          command: docs
+          command: doc
           args: --workspace --features=cargo doc --workspace --features=$(cargo metadata --no-deps | python -c "import sys,json; [print(','.join(x['metadata']['docs.rs']['features'])) for x in json.load(sys.stdin)['packages'] if x['name'] == 'bevy_mod_scripting']")

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
           toolchain: stable
           override: true
       - uses: Swatinem/rust-cache@v2.2.0
-      - uses: actions-rs/cargo@v2
+      - uses: actions-rs/cargo@v1
         with:
           command: doc
           args: --workspace --features=cargo doc --workspace --features=$(cargo metadata --no-deps | python -c "import sys,json; [print(','.join(x['metadata']['docs.rs']['features'])) for x in json.load(sys.stdin)['packages'] if x['name'] == 'bevy_mod_scripting']")

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
           toolchain: stable
           override: true
       - uses: Swatinem/rust-cache@v2.2.0
-      - uses: actions-rs/cargo@v1
+      - uses: actions-rs/cargo@v2
         with:
           command: doc
           args: --workspace --features=cargo doc --workspace --features=$(cargo metadata --no-deps | python -c "import sys,json; [print(','.join(x['metadata']['docs.rs']['features'])) for x in json.load(sys.stdin)['packages'] if x['name'] == 'bevy_mod_scripting']")

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,3 +82,19 @@ jobs:
         with:
           command: test
           args: --workspace --features=lua54,rhai,teal,lua_script_api,rhai_script_api
+  docs:
+    name: Docs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install alsa and udev
+        run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - uses: Swatinem/rust-cache@v2.2.0
+      - uses: actions-rs/cargo@v1
+        with:
+          command: docs
+          args: --workspace --features=cargo doc --workspace --features=$(cargo metadata --no-deps | python -c "import sys,json; [print(','.join(x['metadata']['docs.rs']['features'])) for x in json.load(sys.stdin)['packages'] if x['name'] == 'bevy_mod_scripting']")


### PR DESCRIPTION
Adds a CI step which:
- pulls the "docs.rs" features metadata from the root crate
- passes those to `cargo doc --workspace --features=<features>` and runs the documentation build
- this step should fail PR's if documentation doesn't build

Issue identified in #49 