### PR TITLE
Add hotfix to deal with duplicate fields in teal

### DIFF
--- a/languages/bevy_mod_scripting_lua/Cargo.toml
+++ b/languages/bevy_mod_scripting_lua/Cargo.toml
@@ -42,7 +42,7 @@ path="src/lib.rs"
 [dependencies]
 bevy= { version = "0.10.1", default-features = false}
 bevy_mod_scripting_core = {path="../../bevy_mod_scripting_core", version = "0.2.2" }
-tealr = { version = "=0.9.0-alpha4", git = "https://github.com/awestlake87/tealr", rev = "120ab2da424fbfaaf1a96f77c60072707399a4ba", features=["mlua_vendored","mlua_send"]}
+tealr = { version = "=0.9.0-alpha4", features=["mlua_vendored","mlua_send"]}
 parking_lot = "0.12.1"
 serde_json = "1.0.81"
 serde = { version = "1", features = ["derive"] }


### PR DESCRIPTION
Teal has an issue where using getters and setters causes duplicate fields to appear in the type definition file. This is treated by the teal compiler as an error and prevents using the generated types. This broke the game of life example for teal.

the temporary fix should deal with duplicate fields for now