### PR TITLE
Add fallback logo image pointing to github

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,5 @@
 <p align="center">
-    <img src="./logo_bevy_scripting.svg" width="250">
+    <img src="./logo_bevy_scripting.svg" width="250" onerror="this.onerror=null; this.src='https://raw.githubusercontent.com/makspll/bevy_mod_scripting/main/logo_bevy_scripting.svg'">
 </p>
 
 # Bevy Scripting


### PR DESCRIPTION
Fixes #57 

Instead of including the image in the package, I made it fall back to the file hosted on github. This make it show up in generated doc, but the img src in teh file displayed on github is the same.

Credit for solution: <https://daily-dev-tips.com/posts/html-fallback-images-on-error/>