### PR TITLE
Switched to git dependancy pin rather than patch for tealr

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,11 +20,6 @@ path = "src/documentation/main.rs"
 name = "bevy_mod_scripting"
 path = "src/lib.rs"
 
-
-[patch.crates-io]
-#Patch required for v0.9.0-alpha4 dependancy, unless cargo can be convinced to hard-pin to it.
-tealr = {git="https://github.com/lenscas/tealr.git", rev="05c9cdbace8abb6c12fc200e03a7ffcc5afff308"}
-
 [package.metadata."docs.rs"]
 features = ["lua", "lua54", "rhai", "lua_script_api", "rhai_script_api", "teal"]
 

--- a/languages/bevy_mod_scripting_lua/Cargo.toml
+++ b/languages/bevy_mod_scripting_lua/Cargo.toml
@@ -45,7 +45,8 @@ path="src/lib.rs"
 [dependencies]
 bevy= { version = "0.11", default-features = false}
 bevy_mod_scripting_core = {path="../../bevy_mod_scripting_core", version = "0.3.0" }
-tealr = { version = "=0.9.0-alpha4", features=["mlua_vendored","mlua_send"]}
+#Git pin required for v0.9.0-alpha4 dependancy, without it 0.9.1 is pulled
+tealr = {git="https://github.com/lenscas/tealr.git", rev="05c9cdbace8abb6c12fc200e03a7ffcc5afff308", features=["mlua_vendored","mlua_send"]}
 parking_lot = "0.12.1"
 serde_json = "1.0.81"
 serde = { version = "1", features = ["derive"] }


### PR DESCRIPTION
#91's patch method doesn't work for downstream projects unless they also include the patch. This time I actually tested that my downstream project builds off this version.