### PR TITLE
Script Management Exclusive System Refactor (NEEDS REVIEW)

### DIFF
--- a/bevy_mod_scripting_core/src/event.rs
+++ b/bevy_mod_scripting_core/src/event.rs
@@ -1,6 +1,10 @@
+use bevy::log::error;
 use bevy::prelude::Event;
 
 use crate::{error::ScriptError, hosts::Recipients};
+use crate::hosts::ScriptHost;
+use crate::systems::CachedScriptState;
+use crate::world::WorldPointer;
 
 /// An error coming from a script
 #[derive(Debug, Event)]
@@ -19,4 +23,20 @@ pub struct ScriptLoaded {
 pub trait ScriptEvent: Send + Sync + Clone + Event + 'static {
     /// Retrieves the recipient scripts for this event
     fn recipients(&self) -> &Recipients;
+}
+
+pub fn write_error_event_with_world<H: ScriptHost>(world: WorldPointer, script_name: String, error_text: String) {
+    let mut world = world.write();
+    let mut state: CachedScriptState<H> = world.remove_resource().unwrap();
+
+    let (_, mut error_wrt, _) = state.event_state.get_mut(&mut world);
+
+    let error = ScriptError::RuntimeError {
+        script: script_name,
+        msg: error_text,
+    };
+
+    error!("{}", error);
+    error_wrt.send(ScriptErrorEvent { error });
+    world.insert_resource(state);
 }

--- a/bevy_mod_scripting_core/src/event.rs
+++ b/bevy_mod_scripting_core/src/event.rs
@@ -1,10 +1,10 @@
 use bevy::log::error;
 use bevy::prelude::Event;
 
-use crate::{error::ScriptError, hosts::Recipients};
 use crate::hosts::ScriptHost;
 use crate::systems::CachedScriptState;
 use crate::world::WorldPointer;
+use crate::{error::ScriptError, hosts::Recipients};
 
 /// An error coming from a script
 #[derive(Debug, Event)]
@@ -25,7 +25,11 @@ pub trait ScriptEvent: Send + Sync + Clone + Event + 'static {
     fn recipients(&self) -> &Recipients;
 }
 
-pub fn write_error_event_with_world<H: ScriptHost>(world: WorldPointer, script_name: String, error_text: String) {
+pub fn write_error_event_with_world<H: ScriptHost>(
+    world: WorldPointer,
+    script_name: String,
+    error_text: String,
+) {
     let mut world = world.write();
     let mut state: CachedScriptState<H> = world.remove_resource().unwrap();
 

--- a/bevy_mod_scripting_core/src/systems.rs
+++ b/bevy_mod_scripting_core/src/systems.rs
@@ -38,8 +38,8 @@ pub fn script_add_synchronizer<H: ScriptHost + 'static>(world: &mut World) {
         let changed = state.scripts_changed_query.get(world);
         for (entity, new_scripts, tracker) in changed.iter() {
             q.push((
-                entity.clone(),
-                new_scripts.scripts.iter().cloned().collect::<Vec<_>>(),
+                entity,
+                new_scripts.scripts.to_vec(),
                 tracker.is_added(),
             ))
         }
@@ -53,7 +53,7 @@ pub fn script_add_synchronizer<H: ScriptHost + 'static>(world: &mut World) {
                 Script::<H::ScriptAsset>::insert_new_script_context::<H>(
                     world,
                     &mut host,
-                    &new_script,
+                    new_script,
                     *entity,
                     &script_assets,
                     &mut providers,
@@ -172,7 +172,7 @@ pub fn script_hot_reload_handler<H: ScriptHost>(world: &mut World) {
                     Script::<H::ScriptAsset>::reload_script::<H>(
                         world,
                         &mut host,
-                        &script,
+                        script,
                         &script_assets,
                         &mut providers,
                         &mut contexts,

--- a/bevy_mod_scripting_core/src/systems.rs
+++ b/bevy_mod_scripting_core/src/systems.rs
@@ -19,36 +19,47 @@ pub enum ScriptSystemSet {
 /// Handles creating contexts for new/modified scripts
 /// Scripts are likely not loaded instantly at this point, so most of the time
 /// this system simply inserts an empty context
-pub fn script_add_synchronizer<H: ScriptHost + 'static>(
-    query: Query<
-        (
-            Entity,
-            &ScriptCollection<H::ScriptAsset>,
-            Ref<ScriptCollection<H::ScriptAsset>>,
-        ),
-        Changed<ScriptCollection<H::ScriptAsset>>,
-    >,
-    mut host: ResMut<H>,
-    mut providers: ResMut<APIProviders<H>>,
-    script_assets: Res<Assets<H::ScriptAsset>>,
-    mut contexts: ResMut<ScriptContexts<H::ScriptContext>>,
-    mut event_writer: EventWriter<ScriptLoaded>,
-) {
+pub fn script_add_synchronizer<H: ScriptHost + 'static>(world: &mut World) {
     debug!("Handling addition/modification of scripts");
 
-    query.for_each(|(entity, new_scripts, tracker)| {
-        if tracker.is_added() {
-            new_scripts.scripts.iter().for_each(|new_script| {
+    let mut state: CachedScriptLoadState<H> = world.remove_resource().unwrap();
+
+    // Entity,
+    // &'static ScriptCollection<H::ScriptAsset>,
+    // Ref<'static, ScriptCollection<H::ScriptAsset>>,
+
+    let script_assets: Assets<H::ScriptAsset> = world.remove_resource().unwrap();
+    let mut contexts: ScriptContexts<H::ScriptContext> = world.remove_resource().unwrap();
+    let mut host: H = world.remove_resource().unwrap();
+    let mut providers: APIProviders<H> = world.remove_resource().unwrap();
+
+    let query: Vec<_> = {
+        let mut q = vec![];
+        let changed = state.scripts_changed_query.get(world);
+        for (entity, new_scripts, tracker) in changed.iter() {
+            q.push((
+                entity.clone(),
+                new_scripts.scripts.iter().cloned().collect::<Vec<_>>(),
+                tracker.is_added(),
+            ))
+        }
+        q
+    };
+    world.insert_resource(state);
+
+    for (entity, new_scripts, tracker) in query.iter() {
+        if *tracker {
+            for new_script in new_scripts {
                 Script::<H::ScriptAsset>::insert_new_script_context::<H>(
+                    world,
                     &mut host,
-                    new_script,
-                    entity,
+                    &new_script,
+                    *entity,
                     &script_assets,
                     &mut providers,
                     &mut contexts,
-                    &mut event_writer,
                 )
-            })
+            }
         } else {
             // changed but structure already exists in contexts
             // find out what's changed
@@ -58,14 +69,10 @@ pub fn script_add_synchronizer<H: ScriptHost + 'static>(
             let context_ids = contexts
                 .context_entities
                 .iter()
-                .filter_map(|(sid, (e, _, _))| if *e == entity { Some(sid) } else { None })
+                .filter_map(|(sid, (e, _, _))| if e == entity { Some(sid) } else { None })
                 .cloned()
                 .collect::<HashSet<u32>>();
-            let script_ids = new_scripts
-                .scripts
-                .iter()
-                .map(|s| s.id())
-                .collect::<HashSet<u32>>();
+            let script_ids = new_scripts.iter().map(|s| s.id()).collect::<HashSet<u32>>();
 
             let removed_scripts = context_ids.difference(&script_ids);
             let added_scripts = script_ids.difference(&context_ids);
@@ -75,19 +82,25 @@ pub fn script_add_synchronizer<H: ScriptHost + 'static>(
             }
 
             for a in added_scripts {
-                let script = new_scripts.scripts.iter().find(|e| &e.id() == a).unwrap();
+                let script = new_scripts.iter().find(|e| &e.id() == a).unwrap();
                 Script::<H::ScriptAsset>::insert_new_script_context::<H>(
+                    world,
                     &mut host,
                     script,
-                    entity,
+                    *entity,
                     &script_assets,
                     &mut providers,
                     &mut contexts,
-                    &mut event_writer,
                 )
             }
         }
-    })
+    }
+
+    // return ownership
+    world.insert_resource(script_assets);
+    world.insert_resource(contexts);
+    world.insert_resource(host);
+    world.insert_resource(providers);
 }
 
 /// Handles the removal of script components and their contexts
@@ -112,44 +125,66 @@ pub fn script_remove_synchronizer<H: ScriptHost>(
 }
 
 /// Reloads hot-reloaded scripts, or loads missing contexts for scripts which were added but not loaded
-pub fn script_hot_reload_handler<H: ScriptHost>(
-    mut events: EventReader<AssetEvent<H::ScriptAsset>>,
-    mut host: ResMut<H>,
-    scripts: Query<&ScriptCollection<H::ScriptAsset>>,
-    script_assets: Res<Assets<H::ScriptAsset>>,
-    mut providers: ResMut<APIProviders<H>>,
-    mut contexts: ResMut<ScriptContexts<H::ScriptContext>>,
-    mut event_writer: EventWriter<ScriptLoaded>,
-) {
-    for e in events.iter() {
-        let (handle, created) = match e {
-            AssetEvent::Modified { handle } => (handle, false),
-            AssetEvent::Created { handle } => (handle, true),
-            _ => continue,
-        };
+pub fn script_hot_reload_handler<H: ScriptHost>(world: &mut World) {
+    let mut state: CachedScriptLoadState<H> = world.remove_resource().unwrap();
 
+    let events = {
+        state
+            .event_state
+            .get_mut(world)
+            .1
+            .iter()
+            .filter_map(|e| match e {
+                AssetEvent::Modified { handle } => Some((handle.clone(), false)),
+                AssetEvent::Created { handle } => Some((handle.clone(), true)),
+                _ => None,
+            })
+            .collect::<Vec<_>>()
+    };
+    // collect all asset events up front
+    // let events = events.iter().collect::<Vec<H::ScriptAsset>>();
+    // collect all scripts from query upfront
+    let scripts = state
+        .scripts_query
+        .get(world)
+        .iter()
+        .cloned()
+        .collect::<Vec<_>>();
+
+    world.insert_resource(state);
+
+    let script_assets: Assets<H::ScriptAsset> = world.remove_resource().unwrap();
+    let mut contexts: ScriptContexts<H::ScriptContext> = world.remove_resource().unwrap();
+    let mut host: H = world.remove_resource().unwrap();
+    let mut providers: APIProviders<H> = world.remove_resource().unwrap();
+
+    for (handle, created) in events {
         // find script using this handle by handle id
         // whether this script was modified or created
         // if a script exists with this handle, we should reload it to load in a new context
         // which at this point will be either None or Some(outdated context)
         // both ways are fine
         for scripts in scripts.iter() {
-            for script in &scripts.scripts {
+            for script in scripts.scripts.iter() {
                 // the script could have well loaded in the same frame that it was added
                 // in that case it will have a context attached and we do not want to reload it
-                if script.handle() == handle && !(contexts.has_context(script.id()) && created) {
+                if script.handle() == &handle && !(contexts.has_context(script.id()) && created) {
                     Script::<H::ScriptAsset>::reload_script::<H>(
+                        world,
                         &mut host,
-                        script,
+                        &script,
                         &script_assets,
                         &mut providers,
                         &mut contexts,
-                        &mut event_writer,
                     );
                 }
             }
         }
     }
+    world.insert_resource(script_assets);
+    world.insert_resource(contexts);
+    world.insert_resource(host);
+    world.insert_resource(providers);
 }
 
 /// Lets the script host handle all script events
@@ -221,6 +256,47 @@ impl<H: ScriptHost> FromWorld for CachedScriptState<H> {
     fn from_world(world: &mut World) -> Self {
         Self {
             event_state: SystemState::new(world),
+        }
+    }
+}
+
+#[derive(Resource)]
+/// system state for exclusive systems dealing with script load events
+pub struct CachedScriptLoadState<H: ScriptHost> {
+    pub event_state: SystemState<(
+        EventWriter<'static, ScriptLoaded>,
+        EventReader<'static, 'static, AssetEvent<H::ScriptAsset>>,
+        // Query<'static, 'static,
+        //     (
+        //         Entity,
+        //         &'static ScriptCollection<H::ScriptAsset>,
+        //         Ref<'static, ScriptCollection<H::ScriptAsset>>,
+        //     ),
+        //     Changed<ScriptCollection<H::ScriptAsset>>,
+        // >
+    )>,
+    pub scripts_query:
+        SystemState<Query<'static, 'static, &'static ScriptCollection<H::ScriptAsset>>>,
+    pub scripts_changed_query: SystemState<
+        Query<
+            'static,
+            'static,
+            (
+                Entity,
+                &'static ScriptCollection<H::ScriptAsset>,
+                Ref<'static, ScriptCollection<H::ScriptAsset>>,
+            ),
+            Changed<ScriptCollection<H::ScriptAsset>>,
+        >,
+    >,
+}
+
+impl<H: ScriptHost> FromWorld for crate::systems::CachedScriptLoadState<H> {
+    fn from_world(world: &mut World) -> Self {
+        Self {
+            event_state: SystemState::new(world),
+            scripts_query: SystemState::new(world),
+            scripts_changed_query: SystemState::new(world),
         }
     }
 }

--- a/bevy_mod_scripting_core/src/systems.rs
+++ b/bevy_mod_scripting_core/src/systems.rs
@@ -37,11 +37,7 @@ pub fn script_add_synchronizer<H: ScriptHost + 'static>(world: &mut World) {
         let mut q = vec![];
         let changed = state.scripts_changed_query.get(world);
         for (entity, new_scripts, tracker) in changed.iter() {
-            q.push((
-                entity,
-                new_scripts.scripts.to_vec(),
-                tracker.is_added(),
-            ))
+            q.push((entity, new_scripts.scripts.to_vec(), tracker.is_added()))
         }
         q
     };

--- a/bevy_mod_scripting_core/src/systems.rs
+++ b/bevy_mod_scripting_core/src/systems.rs
@@ -262,14 +262,6 @@ pub struct CachedScriptLoadState<H: ScriptHost> {
     pub event_state: SystemState<(
         EventWriter<'static, ScriptLoaded>,
         EventReader<'static, 'static, AssetEvent<H::ScriptAsset>>,
-        // Query<'static, 'static,
-        //     (
-        //         Entity,
-        //         &'static ScriptCollection<H::ScriptAsset>,
-        //         Ref<'static, ScriptCollection<H::ScriptAsset>>,
-        //     ),
-        //     Changed<ScriptCollection<H::ScriptAsset>>,
-        // >
     )>,
     pub scripts_query:
         SystemState<Query<'static, 'static, &'static ScriptCollection<H::ScriptAsset>>>,

--- a/bevy_script_api/src/lua/std.rs
+++ b/bevy_script_api/src/lua/std.rs
@@ -6,7 +6,7 @@ use bevy_mod_scripting_lua::tealr;
 
 use bevy_mod_scripting_lua::tealr::ToTypename;
 use tealr::mlu::mlua::MetaMethod;
-use tealr::mlu::TypedFunction;
+
 use tealr::mlu::{
     mlua::{self, FromLua, IntoLua, Lua, UserData, Value},
     TealData, TealDataMethods,

--- a/bevy_script_api/src/lua/std.rs
+++ b/bevy_script_api/src/lua/std.rs
@@ -6,7 +6,7 @@ use bevy_mod_scripting_lua::tealr;
 
 use bevy_mod_scripting_lua::tealr::ToTypename;
 use tealr::mlu::mlua::MetaMethod;
-
+use tealr::mlu::TypedFunction;
 use tealr::mlu::{
     mlua::{self, FromLua, IntoLua, Lua, UserData, Value},
     TealData, TealDataMethods,

--- a/languages/bevy_mod_scripting_lua/src/lib.rs
+++ b/languages/bevy_mod_scripting_lua/src/lib.rs
@@ -125,9 +125,7 @@ impl<A: LuaArg> ScriptHost for LuaScriptHost<A> {
             .setup_runtime_all(world.clone(), script_data, &mut lua)
             .expect("Could not setup script runtime");
 
-        {
-            providers.attach_all(&mut lua)?;
-        }
+        providers.attach_all(&mut lua)?;
 
         // We do this twice to get around the issue of attach_all overriding values here for the sake of
         // documenting, TODO: this is messy, shouldn't be a problem but it's messy

--- a/languages/bevy_mod_scripting_lua/src/lib.rs
+++ b/languages/bevy_mod_scripting_lua/src/lib.rs
@@ -121,7 +121,7 @@ impl<A: LuaArg> ScriptHost for LuaScriptHost<A> {
         let mut lua = Mutex::new(lua);
 
         providers
-            .setup_runtime_all(world.clone(), &script_data, &mut lua)
+            .setup_runtime_all(world.clone(), script_data, &mut lua)
             .expect("Could not setup script runtime");
 
         providers.attach_all(&mut lua)?;

--- a/languages/bevy_mod_scripting_rhai/src/lib.rs
+++ b/languages/bevy_mod_scripting_rhai/src/lib.rs
@@ -9,7 +9,9 @@ use std::marker::PhantomData;
 
 pub mod assets;
 pub mod docs;
+use bevy_mod_scripting_core::world::WorldPointer;
 pub use rhai;
+
 pub mod prelude {
     pub use crate::{
         assets::{RhaiFile, RhaiLoader},
@@ -78,6 +80,7 @@ impl<A: FuncArgs + Send + Clone + Sync + 'static> ScriptHost for RhaiScriptHost<
             .add_asset::<RhaiFile>()
             .init_asset_loader::<RhaiLoader>()
             .init_resource::<CachedScriptState<Self>>()
+            .init_resource::<CachedScriptLoadState<Self>>()
             .init_resource::<ScriptContexts<Self::ScriptContext>>()
             .init_resource::<APIProviders<Self>>()
             .register_type::<ScriptCollection<Self::ScriptAsset>>()
@@ -115,6 +118,7 @@ impl<A: FuncArgs + Send + Clone + Sync + 'static> ScriptHost for RhaiScriptHost<
 
     fn load_script(
         &mut self,
+        world_pointer: WorldPointer,
         script: &[u8],
         script_data: &ScriptData,
         _: &mut APIProviders<Self>,

--- a/languages/bevy_mod_scripting_rhai/src/lib.rs
+++ b/languages/bevy_mod_scripting_rhai/src/lib.rs
@@ -118,7 +118,7 @@ impl<A: FuncArgs + Send + Clone + Sync + 'static> ScriptHost for RhaiScriptHost<
 
     fn load_script(
         &mut self,
-        world_pointer: WorldPointer,
+        _world_pointer: WorldPointer,
         script: &[u8],
         script_data: &ScriptData,
         _: &mut APIProviders<Self>,

--- a/languages/bevy_mod_scripting_rune/src/lib.rs
+++ b/languages/bevy_mod_scripting_rune/src/lib.rs
@@ -146,7 +146,7 @@ impl<A: RuneArgs> ScriptHost for RuneScriptHost<A> {
 
     fn load_script(
         &mut self,
-        world_ptr: WorldPointer,
+        _world_ptr: WorldPointer,
         script: &[u8],
         script_data: &ScriptData,
         providers: &mut APIProviders<Self>,

--- a/languages/bevy_mod_scripting_rune/src/lib.rs
+++ b/languages/bevy_mod_scripting_rune/src/lib.rs
@@ -146,7 +146,7 @@ impl<A: RuneArgs> ScriptHost for RuneScriptHost<A> {
 
     fn load_script(
         &mut self,
-        world_ptr: &mut World,
+        world_ptr: WorldPointer,
         script: &[u8],
         script_data: &ScriptData,
         providers: &mut APIProviders<Self>,

--- a/languages/bevy_mod_scripting_rune/src/lib.rs
+++ b/languages/bevy_mod_scripting_rune/src/lib.rs
@@ -146,6 +146,7 @@ impl<A: RuneArgs> ScriptHost for RuneScriptHost<A> {
 
     fn load_script(
         &mut self,
+        world_ptr: &mut World,
         script: &[u8],
         script_data: &ScriptData,
         providers: &mut APIProviders<Self>,


### PR DESCRIPTION
Tentative initial work for exclusive system refactor. Still in todo:

- [ ] quality check some of the changes (spent most of the time fighting the borrow checker). 
- [ ] make sure the new interface is correctly added to each script host implementation
- [x] figure out why even with this, trying to get  world from an attach api bound function is returning nil
- [ ] implement usage of world access to rune and rhai (maybe this should be its own PR)
- [ ] the script reload system makes a clone of all loaded script handles due to lifetime reasons. Lessening this would be ideal.
- [ ] update relevant documentation about script load system
- [ ] maybe increment semvar?

example of what is trying to be fixed
```rs
fn attach_api(&mut self, ctx: &mut Self::APITarget) -> Result<(), ScriptError> {
        // callbacks can receive any `ToLuaMulti` arguments, here '()' and
        // return any `FromLuaMulti` arguments, here a `usize`
        // check the Rlua documentation for more details

        println!("ATTACHED API");

        let ctx = ctx.get_mut().unwrap();

        ctx.globals()
            .set(
                "print2",
                ctx.create_function(|ctx, msg: String| {
                    println!("RUNNING PRINT COMMAND");
                    // retrieve the world pointer
                    let world = match (ctx.get_world()) { // <---------------------------------- THIS FAILS when called during script load
                        Ok(world) => world,
                        Err(e) => {
                            error!("print() failed to get world from ctx: {e}");
                            return Ok(());
                        }
                    };
                    println!("GOT WORLD");
                    let mut world = world.write();
                    println!("GOT WRITE ACCESS TO WORLD");

                    let mut events: Mut<Events<PrintConsoleLine>> =
                        world.get_resource_mut().unwrap();
                    println!("GOT EVENT WRITER");
                    events.send(PrintConsoleLine { line: msg.into() });
                    println!("SENT EVENT");

                    // return something
                    Ok(())
                })
                .map_err(|e| {
                    println!("print was called and errored. {e}");
                    ScriptError::new_other(e)
                })?,
            )
            .map_err(|e| {
                println!("failed to attach print command. {e}");
                ScriptError::new_other(e)
            })?;

        // equivalent to ctx.globals().set() but for multiple items
        tealr::mlu::set_global_env(Export, ctx).map_err(ScriptError::new_other)?;

        Ok(())
    }
```

# List of changes to api from this PR:

- Made script load and reload api and systems intake a global varialbe
- replaced `event_writer: &mut EventWriter<ScriptLoaded>,` argument to reload and insert new functions with a resource_scope on the world pointer.
- Both api bindings and "world" global are now available during initial script load execution and api initialization
- Script handles are now cloneable and so are script collections
- more script errors are now passed to the event writer (such as script load failure)
- added CachedScriptLoadState system state resource for event writers and queries used by the exclusive system script loading systems