### PR TITLE
Dynamic Queries

### DIFF
--- a/crates/bevy_script_api/src/core_providers.rs
+++ b/crates/bevy_script_api/src/core_providers.rs
@@ -56,6 +56,7 @@ impl bevy_mod_scripting_core::hosts::APIProvider for LuaCoreBevyAPIProvider {
 			.process_type::<bevy_mod_scripting_lua::tealr::mlu::UserDataProxy<crate::lua::bevy::LuaScriptData>>()
 			.process_type::<crate::lua::bevy::LuaTypeRegistration>()
 			.process_type::<crate::lua::std::LuaVec<T>>()
+            .process_type::<crate::lua::bevy::LuaQueryBuilder>()
             },
         ))
     }

--- a/crates/bevy_script_api/src/lua/bevy/mod.rs
+++ b/crates/bevy_script_api/src/lua/bevy/mod.rs
@@ -4,7 +4,7 @@ use crate::common::bevy::{
 use crate::lua::{
     mlua::prelude::{IntoLuaMulti, LuaError, LuaMultiValue},
     tealr::{mlu::TypedFunction, ToTypename},
-    util::{ComponentTuple, QueryResultTuple},
+    util::{VariadicComponents, VariadicQueryResult},
     Lua,
 };
 use crate::providers::bevy_ecs::LuaEntity;
@@ -105,13 +105,13 @@ impl TealData for LuaQueryBuilder {
 
     fn add_methods<'lua, T: TealDataMethods<'lua, Self>>(methods: &mut T) {
         methods.document("Filters out entities without any of the components passed");
-        methods.add_method_mut("with", |_, s, components: ComponentTuple| {
+        methods.add_method_mut("with", |_, s, components: VariadicComponents| {
             s.with(components.0);
             Ok(s.clone())
         });
 
         methods.document("Filters out entities with any components passed");
-        methods.add_method_mut("without", |_, s, components: ComponentTuple| {
+        methods.add_method_mut("without", |_, s, components: VariadicComponents| {
             s.without(components.0);
             Ok(s.clone())
         });
@@ -129,12 +129,12 @@ impl TealData for LuaQueryBuilder {
                 move |_, ()| {
                     let o = if curr_idx < len {
                         let query_result = query_result.get(curr_idx).unwrap();
-                        QueryResultTuple::Some(
+                        VariadicQueryResult::Some(
                             LuaEntity::new(query_result.0),
                             query_result.1.clone(),
                         )
                     } else {
-                        QueryResultTuple::None
+                        VariadicQueryResult::None
                     };
                     curr_idx += 1;
                     Ok(o)
@@ -202,7 +202,7 @@ impl TealData for LuaWorld {
 
         methods.document("Creates a LuaQueryBuilder, querying for the passed components types.");
         methods.document("Can be iterated over using `LuaQueryBuilder:iter()`");
-        methods.add_method_mut("query", |_, world, components: ComponentTuple| {
+        methods.add_method_mut("query", |_, world, components: VariadicComponents| {
             Ok(LuaQueryBuilder::new(world.clone())
                 .components(components.0)
                 .clone())

--- a/crates/bevy_script_api/src/lua/util.rs
+++ b/crates/bevy_script_api/src/lua/util.rs
@@ -91,9 +91,9 @@ impl<T: ToTypename> ToTypename for DummyTypeName<T> {
 
 /// A utility type that allows us to accept any number of components as a parameter into a function.
 #[derive(Clone)]
-pub struct ComponentTuple(pub Vec<LuaTypeRegistration>);
+pub struct VariadicComponents(pub Vec<LuaTypeRegistration>);
 
-impl IntoLuaMulti<'_> for ComponentTuple {
+impl IntoLuaMulti<'_> for VariadicComponents {
     fn into_lua_multi(self, lua: &Lua) -> Result<LuaMultiValue<'_>, LuaError> {
         let values = LuaMultiValue::from_vec(
             self.0
@@ -106,9 +106,9 @@ impl IntoLuaMulti<'_> for ComponentTuple {
     }
 }
 
-impl FromLuaMulti<'_> for ComponentTuple {
-    fn from_lua_multi(value: LuaMultiValue<'_>, lua: &Lua) -> Result<ComponentTuple, LuaError> {
-        Ok(ComponentTuple(
+impl FromLuaMulti<'_> for VariadicComponents {
+    fn from_lua_multi(value: LuaMultiValue<'_>, lua: &Lua) -> Result<VariadicComponents, LuaError> {
+        Ok(VariadicComponents(
             value
                 .into_vec()
                 .into_iter()
@@ -118,10 +118,10 @@ impl FromLuaMulti<'_> for ComponentTuple {
     }
 }
 
-impl TealMultiValue for ComponentTuple {
+impl TealMultiValue for VariadicComponents {
     fn get_types_as_params() -> Vec<FunctionParam> {
         vec![FunctionParam {
-            // `...:T` will be a variadic parameter
+            // `...:T` will be a variadic type
             param_name: Some(Name("...".into())),
             ty: LuaTypeRegistration::to_typename(),
         }]
@@ -130,15 +130,15 @@ impl TealMultiValue for ComponentTuple {
 
 /// A utility enum that allows us to return an entity and any number of components from a function.
 #[derive(Clone)]
-pub enum QueryResultTuple {
+pub enum VariadicQueryResult {
     Some(LuaEntity, Vec<ReflectReference>),
     None,
 }
 
-impl IntoLuaMulti<'_> for QueryResultTuple {
+impl IntoLuaMulti<'_> for VariadicQueryResult {
     fn into_lua_multi(self, lua: &Lua) -> Result<LuaMultiValue<'_>, LuaError> {
         match self {
-            QueryResultTuple::Some(entity, vec) => {
+            VariadicQueryResult::Some(entity, vec) => {
                 let mut values = LuaMultiValue::from_vec(
                     vec.into_iter()
                         .map(|v| v.into_lua(lua))
@@ -148,12 +148,12 @@ impl IntoLuaMulti<'_> for QueryResultTuple {
                 values.push_front(entity.into_lua(lua)?);
                 Ok(values)
             }
-            QueryResultTuple::None => Ok(().into_lua_multi(lua)?),
+            VariadicQueryResult::None => Ok(().into_lua_multi(lua)?),
         }
     }
 }
 
-impl TealMultiValue for QueryResultTuple {
+impl TealMultiValue for VariadicQueryResult {
     fn get_types_as_params() -> Vec<FunctionParam> {
         vec![
             FunctionParam {


### PR DESCRIPTION
Fixes #20 
Adds API methods for dynamic queries, using the new QueryBuilder added in Bevy 0.13.
Both Lua and Rhai have implementations as well as types for Teal.

Lua:
```lua
local ComponentOne = world:get_type_by_name("ComponentOne")
local ComponentTwo = world:get_type_by_name("ComponentTwo")
local ComponentThree = world:get_type_by_name("ComponentThree")
local ComponentFour = world:get_type_by_name("ComponentFour")

-- `world:query` accepts any number of `LuaTypeRegistration`
-- returns a `LuaQueryBuilder` which can be used to further filter the query with the `:with` and `:without` methods
-- `LuaQueryBuilder` has an `:iter` method which resolves the query and returns an iterator over the entities and components

for entity, componentOne, componentTwo in world:query(ComponentOne, ComponentTwo):with(ComponentThree):without(ComponentFour):iter() do
    print(entity, componentOne, componentTwo)
end
```

Rhai:
```rs
let component_one = world.get_type_by_name("ComponentOne");
let component_two = world.get_type_by_name("ComponentTwo");
let component_three = world.get_type_by_name("ComponentThree");
let component_four = world.get_type_by_name("ComponentFour");

// `world.query` accepts an array of `ScriptTypeRegistration`
// returns a `ScriptQueryBuilder` which can be used to further filter the query with the `.with` and `.without` methods
// Iterating over `ScriptQueryBuilder` will resolve the query

for results in world.query([ ComponentOne, ComponentTwo ]).with([ ComponentThree ]).without([ ComponentFour ]) {
    // `results` is an object map, keys being the type name of the component, and the values being the entities' component
    // `results` also has a `Entity` key, being the entity the query matched against
    print(results.Entity);
    print(results.ComponentOne);
    print(results.ComponentTwo);
}
```