### PR TITLE
Documentation generation hotfixes

### DIFF
--- a/crates/languages/bevy_mod_scripting_lua/src/docs.rs
+++ b/crates/languages/bevy_mod_scripting_lua/src/docs.rs
@@ -100,12 +100,6 @@ impl DocFragment for LuaDocFragment {
         // fixes bug in tealr which causes syntax errors in teal due to duplicate fields (from having both getters and setters)
         tw.given_types.iter_mut().for_each(|tg| {
             if let TypeGenerator::Record(rg) = tg {
-                let rgname = rg
-                    .type_name
-                    .to_vec()
-                    .into_iter()
-                    .map(|raw: NamePart| raw.as_ref_str().to_owned())
-                    .collect::<Vec<_>>();
                 rg.fields
                     .sort_by(|f1, f2| f1.name.deref().cmp(&f2.name.deref()));
                 rg.fields.dedup_by(|a, b| a.name == b.name);

--- a/crates/languages/bevy_mod_scripting_lua/src/docs.rs
+++ b/crates/languages/bevy_mod_scripting_lua/src/docs.rs
@@ -9,7 +9,7 @@ use std::{
 };
 
 //use bevy::asset::FileAssetIo;
-use bevy::{asset::io::file::FileAssetReader, log::info};
+use bevy::asset::io::file::FileAssetReader;
 use bevy_mod_scripting_core::prelude::*;
 use tealr::{NameContainer, NamePart, TypeGenerator, TypeWalker};
 
@@ -106,7 +106,6 @@ impl DocFragment for LuaDocFragment {
                     .into_iter()
                     .map(|raw: NamePart| raw.as_ref_str().to_owned())
                     .collect::<Vec<_>>();
-                info!("Encountered type: {:?}", rgname);
                 rg.fields
                     .sort_by(|f1, f2| f1.name.deref().cmp(&f2.name.deref()));
                 rg.fields.dedup_by(|a, b| a.name == b.name);
@@ -216,14 +215,13 @@ impl DocFragment for LuaDocFragment {
 fn escape_name(raw: &mut NameContainer) {
     // List of Lua reserved keywords
     const KEYWORD_FIELDS: &[&str] = &[
-        // Values
-        "false", "true", "nil", // Operators
-        "and", "not", "or", // If-Else
-        "if", "then", "else", "elseif", "end", // Loops
-        "for", "in", "break", "do", "repeat", "until", "while", // Funcs
-        "function", "return", // Declarations
-        "local",  // Teal extra
-        "record",
+        "false", "true", "nil", // Values
+        "and", "not", "or", // Operators
+        "if", "then", "else", "elseif", "end", // If-Else
+        "for", "in", "break", "do", "repeat", "until", "while", // Loops
+        "function", "return", // Funcs
+        "local",  // Declarations
+        "record", // Teal extra
     ];
     let Ok(name) = str::from_utf8(&raw) else {
         return;

--- a/crates/languages/bevy_mod_scripting_lua/src/docs.rs
+++ b/crates/languages/bevy_mod_scripting_lua/src/docs.rs
@@ -1,14 +1,17 @@
+use core::str;
 use std::{
+    borrow::Cow,
     env,
     fs::{self, File},
     io::Write,
+    ops::Deref,
     process::Command,
 };
 
 //use bevy::asset::FileAssetIo;
-use bevy::asset::io::file::FileAssetReader;
+use bevy::{asset::io::file::FileAssetReader, log::info};
 use bevy_mod_scripting_core::prelude::*;
-use tealr::{TypeGenerator, TypeWalker};
+use tealr::{NameContainer, NamePart, TypeGenerator, TypeWalker};
 
 pub type TypeWalkerBuilder = fn(TypeWalker) -> TypeWalker;
 
@@ -97,7 +100,31 @@ impl DocFragment for LuaDocFragment {
         // fixes bug in tealr which causes syntax errors in teal due to duplicate fields (from having both getters and setters)
         tw.given_types.iter_mut().for_each(|tg| {
             if let TypeGenerator::Record(rg) = tg {
+                let rgname = rg
+                    .type_name
+                    .to_vec()
+                    .into_iter()
+                    .map(|raw: NamePart| raw.as_ref_str().to_owned())
+                    .collect::<Vec<_>>();
+                info!("Encountered type: {:?}", rgname);
+                rg.fields
+                    .sort_by(|f1, f2| f1.name.deref().cmp(&f2.name.deref()));
                 rg.fields.dedup_by(|a, b| a.name == b.name);
+                rg.static_fields
+                    .sort_by(|f1, f2| f1.name.deref().cmp(&f2.name.deref()));
+                rg.static_fields.dedup_by(|a, b| a.name == b.name);
+                for field in rg.fields.iter_mut().chain(rg.static_fields.iter_mut()) {
+                    escape_name(&mut field.name);
+                }
+                for func in rg
+                    .functions
+                    .iter_mut()
+                    .chain(rg.mut_functions.iter_mut())
+                    .chain(rg.methods.iter_mut())
+                    .chain(rg.mut_methods.iter_mut())
+                {
+                    escape_name(&mut func.name);
+                }
             }
         });
 
@@ -170,5 +197,39 @@ impl DocFragment for LuaDocFragment {
             }
         }
         Ok(())
+    }
+}
+
+/// Escapes a name of a table field, if that table field is a reserved keyword.
+///
+/// ## Background
+///
+/// String keys in a Lua table are allowed to be anything, even reserved
+/// keywords. By default when tealr generates the type definition for a table
+/// field, the string it generates is `{name} : {type}`. This causes a syntax
+/// error when writing a bare keyword, since `nil : {type}` is considered trying
+/// to add a type to the *value* nil (which is invalid).
+///
+/// To get around this tealr allows us to escape table fields using the
+/// `["{name}"] : {value}` syntax. This function detects if a name is one of the
+/// Lua reserved words and fixes it if so.
+fn escape_name(raw: &mut NameContainer) {
+    // List of Lua reserved keywords
+    const KEYWORD_FIELDS: &[&str] = &[
+        // Values
+        "false", "true", "nil", // Operators
+        "and", "not", "or", // If-Else
+        "if", "then", "else", "elseif", "end", // Loops
+        "for", "in", "break", "do", "repeat", "until", "while", // Funcs
+        "function", "return", // Declarations
+        "local",  // Teal extra
+        "record",
+    ];
+    let Ok(name) = str::from_utf8(&raw) else {
+        return;
+    };
+    if KEYWORD_FIELDS.contains(&name) {
+        let mapped = format!("[\"{name}\"]");
+        *raw = NameContainer::from(Cow::Owned(mapped));
     }
 }

--- a/crates/languages/bevy_mod_scripting_lua/src/docs.rs
+++ b/crates/languages/bevy_mod_scripting_lua/src/docs.rs
@@ -11,7 +11,7 @@ use std::{
 //use bevy::asset::FileAssetIo;
 use bevy::asset::io::file::FileAssetReader;
 use bevy_mod_scripting_core::prelude::*;
-use tealr::{NameContainer, NamePart, TypeGenerator, TypeWalker};
+use tealr::{NameContainer, TypeGenerator, TypeWalker};
 
 pub type TypeWalkerBuilder = fn(TypeWalker) -> TypeWalker;
 


### PR DESCRIPTION
Hotfix for 2 bugs in the teal environment generation algorithm: 

* Fixed fields not being deduped correctly because `Vec::dedup` only dedupes *consecutive* duplicate items. This was done by sorting the fields list beforehand. 
    * Also deduped static fields while I was at it, though I'm not sure if those are used? 
* Fixed the algorithm not properly escaping record fields/functions/methods/etc that share the name of an existing Lua/Teal keyword.  This was coming up since the `Uuid` record has a function called `nil` for making an all-zero uuid. 


Note that this still doesn't completely fix Teal document generation when using the default Bevy APIs since they're still missing a definition for `ReflectedValue`, but I'll likely need some guidance on that and will split that off to a separate PR. 