### PR TITLE
feat: make script contexts public

### DIFF
--- a/crates/bevy_mod_scripting_core/src/context.rs
+++ b/crates/bevy_mod_scripting_core/src/context.rs
@@ -13,7 +13,7 @@ pub type ContextId = u32;
 
 #[derive(Resource)]
 pub struct ScriptContexts<P: IntoScriptPluginParams> {
-    pub(crate) contexts: HashMap<ContextId, P::C>,
+    pub contexts: HashMap<ContextId, P::C>,
 }
 
 impl<P: IntoScriptPluginParams> Default for ScriptContexts<P> {


### PR DESCRIPTION
Exposes script contexts to public consumers,
Don't see many reasons not to