### PR TITLE
fix: prevent allocation and component ID ranges from overlapping

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -39,7 +39,7 @@ git_release_body = """
 changelog_include = [
     "bevy_mod_scripting_lua",
     "bevy_mod_scripting_core",
-    # "bevy_mod_scripting_rhai",
+    "bevy_mod_scripting_rhai",
     # "bevy_mod_scripting_rune",
     "bevy_mod_scripting_functions",
 ]

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -53,9 +53,9 @@ version_group = "main"
 name = "bevy_mod_scripting_core"
 version_group = "main"
 
-# [[package]]
-# name = "bevy_mod_scripting_rhai"
-# version_group = "main"
+[[package]]
+name = "bevy_mod_scripting_rhai"
+version_group = "main"
 
 # [[package]]
 # name = "bevy_mod_scripting_rune"


### PR DESCRIPTION
This was a typo which caused clashes in the reflect allocation ID space, meaning things would appear locked when they shouldn't have