### PR TITLE
fix: bump `bevy` to 0.15.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ bevy_mod_scripting_rhai = { path = "crates/languages/bevy_mod_scripting_rhai", v
 bevy_mod_scripting_functions = { workspace = true }
 [workspace.dependencies]
 profiling = { version = "1.0" }
-bevy = { version = "0.15.0", default-features = false }
+bevy = { version = "0.15.1", default-features = false }
 bevy_mod_scripting_core = { path = "crates/bevy_mod_scripting_core", version = "0.9.0" }
 bevy_mod_scripting_functions = { path = "crates/bevy_mod_scripting_functions", version = "0.9.0", default-features = false }
 

--- a/crates/bevy_api_gen/Cargo.bootstrap.toml
+++ b/crates/bevy_api_gen/Cargo.bootstrap.toml
@@ -6,7 +6,7 @@ edition = "2021"
 
 [dependencies]
 bevy_mod_scripting_core = { path = "{{BMS_CORE_PATH}}" }
-bevy_reflect = { version = "0.15.0", features = [
+bevy_reflect = { version = "0.15.1", features = [
     "bevy",
     "glam",
     "petgraph",

--- a/makefile
+++ b/makefile
@@ -22,7 +22,7 @@ TEST_NAME=
 # # valgrind outputs a callgrind.out.<pid>. We can analyze this with kcachegrind
 # kcachegrind
 NIGHTLY_VERSION=nightly-2024-12-15
-BEVY_VERSION=0.15.0
+BEVY_VERSION=0.15.1
 GLAM_VERSION=0.29.0
 CODEGEN_PATH=${PWD}/target/codegen
 BEVY_PATH=${CODEGEN_PATH}/bevy

--- a/readme.md
+++ b/readme.md
@@ -45,6 +45,16 @@ The languages currently supported are as follows:
 
 For examples, installation and usage instructions see our shiny new [book](https://makspll.github.io/bevy_mod_scripting)
 
+## Bevy Compatibility
+
+| bevy_mod_scripting  | bevy   |
+|---------------------|--------|
+| 0.9.1               | 0.15.1 |
+| 0.9                 | 0.15.0 |
+| 0.8                 | 0.15.0 |
+| 0.7                 | 0.14   |
+| 0.6                 | 0.13.1 |
+
 [^1]: Due to the recent re-write of the crate, documentation generation as well as rune support are temporarilly on hold. They will likely be re-implemented in the future.
 
 [^2]: the coverage does not include generated bindings. 


### PR DESCRIPTION
Bumps bindings and supported bevy version to 0.15.1