### PR TITLE
feat: add recipient for specific language

### DIFF
--- a/crates/bevy_mod_scripting_core/src/event.rs
+++ b/crates/bevy_mod_scripting_core/src/event.rs
@@ -122,6 +122,8 @@ pub enum Recipients {
     Script(ScriptId),
     /// The event is to be handled by all the scripts on the specified entity
     Entity(Entity),
+    /// The event is to be handled by all the scripts of one language
+    Language(crate::asset::Language),
 }
 
 /// A callback event meant to trigger a callback in a subset/set of scripts in the world with the given arguments

--- a/crates/bevy_mod_scripting_core/src/handler.rs
+++ b/crates/bevy_mod_scripting_core/src/handler.rs
@@ -129,6 +129,11 @@ pub(crate) fn event_handler_internal<L: IntoCallbackLabel, P: IntoScriptPluginPa
                     crate::event::Recipients::Entity(target_entity) if target_entity != entity => {
                         continue
                     }
+                    crate::event::Recipients::Language(target_language)
+                    if *target_language != P::LANGUAGE =>
+                        {
+                            continue
+                        }
                     _ => (),
                 }
                 let script = match res_ctxt.scripts.scripts.get(script_id) {


### PR DESCRIPTION
This is useful when you have BMS as a plugin system and want multiple languages implemented. You also want the events for different languages to be sent on different schedules. You need all language scripts to be on a dedicated entity and can not put them all on one “Language” entity. 