### PR TITLE
fix: make `extractors` module non-public

### DIFF
--- a/crates/bevy_mod_scripting_core/src/lib.rs
+++ b/crates/bevy_mod_scripting_core/src/lib.rs
@@ -23,6 +23,8 @@ use handler::{CallbackSettings, HandlerFn};
 use runtime::{initialize_runtime, Runtime, RuntimeContainer, RuntimeInitializer, RuntimeSettings};
 use script::Scripts;
 
+mod extractors;
+
 pub mod asset;
 pub mod bindings;
 pub mod commands;
@@ -30,7 +32,6 @@ pub mod context;
 pub mod docgen;
 pub mod error;
 pub mod event;
-pub mod extractors;
 pub mod handler;
 pub mod reflection_extensions;
 pub mod runtime;


### PR DESCRIPTION
The module contains no public items anyway and makes docs a bit more confusing.