### PR TITLE
feat: Add `script_bindings` impl block derive macro

### DIFF
--- a/.github/workflows/bevy_mod_scripting.yml
+++ b/.github/workflows/bevy_mod_scripting.yml
@@ -31,6 +31,27 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+
+  check-needs-run:
+    outputs:
+      any-changes: ${{ steps.changes.outputs.src }}
+    permissions:
+      pull-requests: read
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: changes
+        with:
+          base: main
+          filters: |
+            src:
+              - 'src/**'
+              - 'docs/**'
+              - '.github/workflows/bevy_mod_scripting.yml'
+
+
   generate-job-matrix:
     runs-on: ubuntu-latest
     # container: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
@@ -49,13 +70,14 @@ jobs:
           echo "matrix=$(cat matrix-one-line.json)" >> $GITHUB_OUTPUT
 
   check:  
+    needs: [check-needs-run]
     permissions:
       pull-requests: write
       contents: write
       issues: write
     name: Check - ${{ matrix.run_args.name }}
     runs-on: ${{ matrix.run_args.os }}
-    # container: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+    if: ${{ needs.check-needs-run.outputs.any-changes == 'true' }}
     needs: 
       - generate-job-matrix
     strategy:

--- a/.github/workflows/bevy_mod_scripting.yml
+++ b/.github/workflows/bevy_mod_scripting.yml
@@ -3,15 +3,9 @@ on:
     branches:
       - main
       - staging
-    paths-ignore:
-      - '.github/workflows/release-plz.yml'
-      - 'docs/**'
   pull_request:
     branches:
       - "**"
-    paths-ignore:
-      - '.github/workflows/release-plz.yml'
-      - 'docs/**'
 
 
 name: CI

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,11 +57,14 @@ bevy_mod_scripting_lua = { path = "crates/languages/bevy_mod_scripting_lua", ver
 bevy_mod_scripting_rhai = { path = "crates/languages/bevy_mod_scripting_rhai", version = "0.9.3", optional = true }
 # bevy_mod_scripting_rune = { path = "crates/languages/bevy_mod_scripting_rune", version = "0.9.0-alpha.2", optional = true }
 bevy_mod_scripting_functions = { workspace = true }
+bevy_mod_scripting_derive = { workspace = true }
+
 [workspace.dependencies]
 profiling = { version = "1.0" }
 bevy = { version = "0.15.1", default-features = false }
 bevy_mod_scripting_core = { path = "crates/bevy_mod_scripting_core", version = "0.9.3" }
 bevy_mod_scripting_functions = { path = "crates/bevy_mod_scripting_functions", version = "0.9.3", default-features = false }
+bevy_mod_scripting_derive = { path = "crates/bevy_mod_scripting_derive", version = "0.9.3" }
 
 # test utilities
 script_integration_test_harness = { path = "crates/script_integration_test_harness" }
@@ -85,6 +88,7 @@ members = [
     "crates/bevy_mod_scripting_functions",
     "crates/xtask",
     "crates/script_integration_test_harness",
+    "crates/bevy_mod_scripting_derive",
 ]
 resolver = "2"
 exclude = ["crates/bevy_api_gen", "crates/macro_tests"]

--- a/crates/bevy_mod_scripting_core/Cargo.toml
+++ b/crates/bevy_mod_scripting_core/Cargo.toml
@@ -41,6 +41,8 @@ smallvec = "1.11"
 itertools = "0.13"
 derivative = "2.2"
 profiling = { workspace = true }
+bevy_mod_scripting_derive = { workspace = true }
+
 [dev-dependencies]
 test_utils = { workspace = true }
 tokio = { version = "1", features = ["rt", "macros"] }

--- a/crates/bevy_mod_scripting_core/src/docgen/info.rs
+++ b/crates/bevy_mod_scripting_core/src/docgen/info.rs
@@ -78,6 +78,20 @@ impl FunctionInfo {
         self.docs = Some(docs.into());
         self
     }
+
+    /// Add argument names to the function info.
+    ///
+    /// If the number of argument names is less than the number of arguments, the remaining arguments will be unnamed.
+    /// If the number of argument names is greater than the number of arguments, the extra argument names will be ignored.
+    pub fn with_arg_names(mut self, arg_names: &[&'static str]) -> Self {
+        self.arg_info
+            .iter_mut()
+            .zip(arg_names.iter())
+            .for_each(|(arg, name)| {
+                arg.name = Some(Cow::Borrowed(*name));
+            });
+        self
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Reflect)]

--- a/crates/bevy_mod_scripting_derive/Cargo.toml
+++ b/crates/bevy_mod_scripting_derive/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "bevy_mod_scripting_derive"
+version = "0.9.3"
+edition = "2021"
+authors = ["Maksymilian Mozolewski <makspl17@gmail.com>"]
+license = "MIT OR Apache-2.0"
+description = "Necessary functionality for Lua support with bevy_mod_scripting"
+repository = "https://github.com/makspll/bevy_mod_scripting"
+homepage = "https://github.com/makspll/bevy_mod_scripting"
+keywords = ["bevy", "gamedev", "scripting", "rhai"]
+categories = ["game-development"]
+readme = "readme.md"
+
+[dependencies]
+syn = "2"
+proc-macro2 = "1"
+quote = "1"
+
+[lib]
+proc-macro = true
+
+[lints]
+workspace = true

--- a/crates/bevy_mod_scripting_derive/readme.md
+++ b/crates/bevy_mod_scripting_derive/readme.md
@@ -1,0 +1,3 @@
+# bevy_mod_scripting_lua_derive
+
+This crate is a part of the ["bevy_mod_scripting" workspace](https://github.com/makspll/bevy_mod_scripting).

--- a/crates/bevy_mod_scripting_derive/src/lib.rs
+++ b/crates/bevy_mod_scripting_derive/src/lib.rs
@@ -1,0 +1,193 @@
+//! Derive macros for BMS
+
+use proc_macro2::{Span, TokenStream};
+use quote::{format_ident, quote_spanned, ToTokens};
+use syn::{spanned::Spanned, ImplItemFn, ItemImpl};
+
+/// Derive macro for generating script bindings from an impl block.
+///
+/// Does not support generics.
+///
+/// Arguments:
+/// - `name`: the name to use to suffix the generated function, i.e. `test_fn` will generate `register_test_fn. Defaults to `functions`
+/// - `remote`: If true the original impl block will be ignored, and only the function registrations will be generated
+/// - `bms_core_path`: If set the path to override bms imports, normally only used internally
+#[proc_macro_attribute]
+pub fn script_bindings(
+    args: proc_macro::TokenStream,
+    input: proc_macro::TokenStream,
+) -> proc_macro::TokenStream {
+    let args = syn::parse_macro_input!(args as Args);
+
+    let impl_block = syn::parse_macro_input!(input as ItemImpl);
+    let impl_span = impl_block.span();
+    // let (impl_generics, ty_generics, where_clause) = impl_block.generics.split_for_impl();
+
+    let type_ident_with_generics = &impl_block.self_ty;
+    let mut function_registrations = Vec::with_capacity(impl_block.items.len());
+    for i in &impl_block.items {
+        match i {
+            syn::ImplItem::Fn(impl_item_fn) => {
+                let fun = process_impl_fn(impl_item_fn);
+                function_registrations.push(fun);
+            }
+            _ => continue,
+        }
+    }
+
+    let impl_block = match args.remote {
+        true => TokenStream::default(),
+        false => quote_spanned! {impl_span=>
+            #impl_block
+        },
+    };
+
+    let bms_core_path = &args.bms_core_path;
+
+    let function_name = format_ident!("register_{}", args.name);
+
+    let out = quote_spanned! {impl_span=>
+        fn #function_name(world: &mut bevy::ecs::world::World) {
+            #bms_core_path::bindings::function::namespace::NamespaceBuilder::<#type_ident_with_generics>::new(world)
+                #(#function_registrations)*;
+        }
+
+        #impl_block
+    };
+
+    out.into()
+}
+
+struct Args {
+    /// The name to use to suffix the generated function, i.e. `test_fn` will generate `register_test_fn
+    pub name: syn::Ident,
+    /// If true the original impl block will be ignored, and only the function registrations will be generated
+    pub remote: bool,
+    /// If set the path to override bms imports
+    pub bms_core_path: syn::Path,
+}
+
+impl syn::parse::Parse for Args {
+    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+        // parse separated key-value pairs
+        let pairs =
+            syn::punctuated::Punctuated::<syn::Meta, syn::Token![,]>::parse_terminated(input)?;
+
+        let mut name = syn::Ident::new("functions", Span::call_site());
+        let mut remote = false;
+        let mut bms_core_path =
+            syn::Path::from(syn::Ident::new("bevy_mod_scripting", Span::call_site()));
+        bms_core_path.segments.push(syn::PathSegment {
+            ident: syn::Ident::new("core", Span::call_site()),
+            arguments: syn::PathArguments::None,
+        });
+        let mut unknown_spans = Vec::default();
+        for pair in pairs {
+            match &pair {
+                syn::Meta::Path(path) => {
+                    if path.is_ident("remote") {
+                        remote = true;
+                        continue;
+                    }
+                }
+                syn::Meta::NameValue(name_value) => {
+                    if name_value.path.is_ident("bms_core_path") {
+                        if let syn::Expr::Lit(path) = &name_value.value {
+                            if let syn::Lit::Str(lit_str) = &path.lit {
+                                bms_core_path = syn::parse_str(&lit_str.value())?;
+                                continue;
+                            }
+                        }
+                    } else if name_value.path.is_ident("name") {
+                        if let syn::Expr::Lit(path) = &name_value.value {
+                            if let syn::Lit::Str(lit_str) = &path.lit {
+                                name = syn::parse_str(&lit_str.value())?;
+                                continue;
+                            }
+                        }
+                    }
+                }
+                _ => {}
+            }
+
+            unknown_spans.push(pair.span());
+        }
+
+        if !unknown_spans.is_empty() {
+            return Err(syn::Error::new(
+                unknown_spans[0],
+                "Unknown argument to script_bindings",
+            ));
+        }
+
+        Ok(Self {
+            remote,
+            bms_core_path,
+            name,
+        })
+    }
+}
+
+fn stringify_pat_type(pat_type: &syn::Pat) -> String {
+    match pat_type {
+        syn::Pat::Ident(pat_ident) => pat_ident.ident.to_string(),
+        syn::Pat::Type(pat_type) => stringify_pat_type(&pat_type.pat),
+
+        p => p.to_token_stream().to_string(),
+    }
+}
+
+/// Converts an impl block function into a function registration, i.e. a closure which will be used to register this function, as well as
+/// the target function reference and other metadata
+fn process_impl_fn(fun: &ImplItemFn) -> TokenStream {
+    let args = &fun.sig.inputs;
+    let args_names = args.iter().map(|arg| match arg {
+        syn::FnArg::Receiver(_) => syn::LitStr::new("self", Span::call_site()),
+        syn::FnArg::Typed(pat_type) => {
+            syn::LitStr::new(&stringify_pat_type(&pat_type.pat), Span::call_site())
+        }
+    });
+    let body = &fun.block;
+    let docstring = parse_docstring(fun.attrs.iter())
+        .map(|s| syn::LitStr::new(&s, Span::call_site()))
+        .unwrap_or(syn::LitStr::new("", Span::call_site()));
+    let fun_name = syn::LitStr::new(&fun.sig.ident.to_string(), Span::call_site());
+    quote_spanned! {Span::call_site()=>
+        .register_documented(
+            #fun_name,
+            |#args| #body,
+            #docstring,
+            &[#(#args_names),*]
+        )
+    }
+}
+
+/// Ideally we'd be doing something like rustdoc: https://github.com/rust-lang/rust/blob/124cc92199ffa924f6b4c7cc819a85b65e0c3984/compiler/rustc_resolve/src/rustdoc.rs#L102
+/// but that is too much complexity, stripping the first space should be good enough for now.
+fn parse_docstring<'a>(attrs: impl Iterator<Item = &'a syn::Attribute>) -> Option<String> {
+    let docs = attrs.filter_map(|attr| {
+        if attr.path().is_ident("doc") {
+            if let syn::Meta::NameValue(meta_name_value) = &attr.meta {
+                if let syn::Expr::Lit(expr_lit) = &meta_name_value.value {
+                    if let syn::Lit::Str(lit_str) = &expr_lit.lit {
+                        if lit_str.value().len() > 1 {
+                            return Some(lit_str.value()[1..].to_string());
+                        } else {
+                            return Some(lit_str.value());
+                        }
+                    }
+                }
+            }
+        };
+
+        None
+    });
+
+    // join with newline
+    let docs = docs.collect::<Vec<_>>();
+    if docs.is_empty() {
+        return None;
+    }
+
+    Some(docs.join("\n"))
+}

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -54,6 +54,10 @@ name = "bevy_mod_scripting_core"
 version_group = "main"
 
 [[package]]
+name = "bevy_mod_scripting_derive"
+version_group = "main"
+
+[[package]]
 name = "bevy_mod_scripting_rhai"
 version_group = "main"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,4 +19,5 @@ pub mod rhai {
 //     pub use bevy_mod_scripting_rune::*;
 // }
 
+pub use bevy_mod_scripting_derive::*;
 pub use bevy_mod_scripting_functions::*;


### PR DESCRIPTION
Closes #264 

Adds a macro which can be used to generate registrator functions for an impl block i.e.:

```rust
    #[test]
    fn test_macro_generates_correct_registrator_function() {
        #[derive(Reflect)]
        struct TestStruct;

        #[script_bindings(bms_core_path = "crate", name = "test_fn")]
        impl TestStruct {
            /// My docs !!
            fn test_fn(_self: Ref<TestStruct>, mut _arg1: usize) {}
        }

        let mut test_world = bevy::ecs::world::World::default();

        register_test_fn(&mut test_world);

        let app_registry = test_world
            .get_resource::<AppScriptFunctionRegistry>()
            .unwrap();
        let app_registry = app_registry.read();

        let test_fn = app_registry
            .get_function(TestStruct::into_namespace(), "test_fn")
            .unwrap();

        assert_eq!(test_fn.info.docs, Some("My docs !!".into()));
        assert_eq!(test_fn.info.arg_info.len(), 2);

        assert_eq!(
            test_fn.info.arg_info[0].type_id,
            std::any::TypeId::of::<Ref<TestStruct>>()
        );
        assert_eq!(test_fn.info.arg_info[0].name, Some("_self".into()));

        assert_eq!(
            test_fn.info.arg_info[1].type_id,
            std::any::TypeId::of::<usize>()
        );
        assert_eq!(test_fn.info.arg_info[1].name, Some("_arg1".into()));

        assert_eq!(
            test_fn.info.return_info.type_id,
            std::any::TypeId::of::<()>()
        );
    }
```