### PR TITLE
feat: add `TypedThrough` abstraction to function meta, and refactor

### DIFF
--- a/crates/bevy_mod_scripting_core/src/bindings/function/arg_meta.rs
+++ b/crates/bevy_mod_scripting_core/src/bindings/function/arg_meta.rs
@@ -2,7 +2,10 @@
 
 use std::{ffi::OsString, path::PathBuf};
 
-use crate::bindings::{script_value::ScriptValue, ReflectReference};
+use crate::{
+    bindings::{script_value::ScriptValue, ReflectReference},
+    docgen::typed_through::TypedThrough,
+};
 
 use super::{
     from::{FromScript, Mut, Ref, Val},
@@ -15,9 +18,17 @@ use super::{
 pub trait ScriptArgument: ArgMeta + FromScript + GetTypeDependencies {}
 impl<T: ArgMeta + FromScript + GetTypeDependencies> ScriptArgument for T {}
 
+/// Marker trait for types that can be used as arguments to a script function. And contain type information.
+pub trait TypedScriptArgument: TypedThrough + ScriptArgument {}
+impl<T: TypedThrough + ScriptArgument> TypedScriptArgument for T {}
+
 /// Marker trait for types that can be used as return values from a script function.
 pub trait ScriptReturn: IntoScript + GetTypeDependencies {}
 impl<T: IntoScript + GetTypeDependencies> ScriptReturn for T {}
+
+/// Marker trait for types that can be used as return values from a script function. And contain type information.
+pub trait TypedScriptReturn: TypedThrough + ScriptReturn {}
+impl<T: TypedThrough + ScriptReturn> TypedScriptReturn for T {}
 
 /// Describes an argument to a script function. Provides necessary information for the function to handle dispatch.
 pub trait ArgMeta {
@@ -37,13 +48,29 @@ macro_rules! impl_arg_info {
     };
 }
 
-impl_arg_info!(bool, i8, i16, i32, i64, i128, u8, u16, u32, u64, u128, f32, f64, usize, isize);
-
-impl_arg_info!(String, PathBuf, OsString);
-
-impl_arg_info!(char);
-
-impl_arg_info!(ReflectReference);
+impl_arg_info!(
+    bool,
+    i8,
+    i16,
+    i32,
+    i64,
+    i128,
+    u8,
+    u16,
+    u32,
+    u64,
+    u128,
+    f32,
+    f64,
+    usize,
+    isize,
+    String,
+    PathBuf,
+    OsString,
+    char,
+    ReflectReference,
+    &'static str
+);
 
 impl<T> ArgMeta for Val<T> {}
 impl<T> ArgMeta for Ref<'_, T> {}

--- a/crates/bevy_mod_scripting_core/src/bindings/function/mod.rs
+++ b/crates/bevy_mod_scripting_core/src/bindings/function/mod.rs
@@ -66,7 +66,7 @@ mod test {
         assert_eq!(test_fn.info.arg_info[1].name, Some("_arg1".into()));
 
         assert_eq!(
-            test_fn.info.return_info.type_id,
+            test_fn.info.return_info.as_ref().unwrap().type_id,
             std::any::TypeId::of::<()>()
         );
     }

--- a/crates/bevy_mod_scripting_core/src/bindings/function/script_function.rs
+++ b/crates/bevy_mod_scripting_core/src/bindings/function/script_function.rs
@@ -73,12 +73,6 @@ pub struct DynamicScriptFunction {
     >,
 }
 
-impl PartialEq for DynamicScriptFunction {
-    fn eq(&self, other: &Self) -> bool {
-        self.info == other.info
-    }
-}
-
 #[derive(Clone, Reflect)]
 #[reflect(opaque)]
 /// A dynamic mutable script function.
@@ -94,12 +88,6 @@ pub struct DynamicScriptFunctionMut {
                 + 'static,
         >,
     >,
-}
-
-impl PartialEq for DynamicScriptFunctionMut {
-    fn eq(&self, other: &Self) -> bool {
-        self.info == other.info
-    }
 }
 
 impl DynamicScriptFunction {
@@ -212,6 +200,18 @@ impl DynamicScriptFunctionMut {
             },
             func: self.func,
         }
+    }
+}
+
+impl PartialEq for DynamicScriptFunction {
+    fn eq(&self, other: &Self) -> bool {
+        std::ptr::addr_eq(self as *const Self, other as *const Self)
+    }
+}
+
+impl PartialEq for DynamicScriptFunctionMut {
+    fn eq(&self, other: &Self) -> bool {
+        std::ptr::addr_eq(self as *const Self, other as *const Self)
     }
 }
 

--- a/crates/bevy_mod_scripting_core/src/docgen/info.rs
+++ b/crates/bevy_mod_scripting_core/src/docgen/info.rs
@@ -187,6 +187,20 @@ mod test {
 
         assert_eq!(info.arg_info[0].type_id, TypeId::of::<i32>());
         assert_eq!(info.arg_info[1].type_id, TypeId::of::<f32>());
+
+        match info.arg_info[0].type_info.as_ref().unwrap() {
+            ThroughTypeInfo::TypeInfo(type_info) => {
+                assert_eq!(type_info.type_id(), TypeId::of::<i32>());
+            }
+            _ => panic!("Expected TypeInfo"),
+        }
+
+        match info.arg_info[1].type_info.as_ref().unwrap() {
+            ThroughTypeInfo::TypeInfo(type_info) => {
+                assert_eq!(type_info.type_id(), TypeId::of::<f32>());
+            }
+            _ => panic!("Expected TypeInfo"),
+        }
     }
 
     #[test]
@@ -201,5 +215,31 @@ mod test {
 
         assert_eq!(info.arg_info[0].type_id, TypeId::of::<Ref<'static, i32>>());
         assert_eq!(info.arg_info[1].type_id, TypeId::of::<Mut<'static, f32>>());
+
+        match info.arg_info[0].type_info.as_ref().unwrap() {
+            ThroughTypeInfo::UntypedWrapper {
+                through_type,
+                wrapper_type_id,
+                wrapper_name,
+            } => {
+                assert_eq!(through_type.type_id(), TypeId::of::<i32>());
+                assert_eq!(*wrapper_type_id, TypeId::of::<Ref<'static, i32>>());
+                assert_eq!(*wrapper_name, "Ref");
+            }
+            _ => panic!("Expected UntypedWrapper"),
+        }
+
+        match info.arg_info[1].type_info.as_ref().unwrap() {
+            ThroughTypeInfo::UntypedWrapper {
+                through_type,
+                wrapper_type_id,
+                wrapper_name,
+            } => {
+                assert_eq!(through_type.type_id(), TypeId::of::<f32>());
+                assert_eq!(*wrapper_type_id, TypeId::of::<Mut<'static, f32>>());
+                assert_eq!(*wrapper_name, "Mut");
+            }
+            _ => panic!("Expected UntypedWrapper"),
+        }
     }
 }

--- a/crates/bevy_mod_scripting_core/src/docgen/mod.rs
+++ b/crates/bevy_mod_scripting_core/src/docgen/mod.rs
@@ -1,2 +1,3 @@
 //! Documentation generation for scripting languages.
 pub mod info;
+pub mod typed_through;

--- a/crates/bevy_mod_scripting_core/src/docgen/typed_through.rs
+++ b/crates/bevy_mod_scripting_core/src/docgen/typed_through.rs
@@ -1,0 +1,262 @@
+//! Defines a set of traits which destruture [`bevy::reflect::TypeInfo`] and implement a light weight wrapper around it, to allow types
+//! which normally can't implement [`bevy::reflect::Typed`] to be used in a reflection context.
+
+use std::{any::TypeId, ffi::OsString, path::PathBuf};
+
+use bevy::reflect::{TypeInfo, Typed};
+
+use crate::{
+    bindings::{
+        function::{
+            from::{Mut, Ref, Val},
+            script_function::{
+                DynamicScriptFunction, DynamicScriptFunctionMut, FunctionCallContext,
+            },
+        },
+        script_value::ScriptValue,
+        ReflectReference,
+    },
+    error::InteropError,
+};
+
+/// All Through types follow one rule:
+/// - A through type can not contain a nested through type. It must always contain a fully typed inner type.
+///
+/// This means that:
+/// - `Ref<Ref<T>>` is not allowed, but `Ref<T>` is.
+///
+/// i.e. `Ref`, `Mut` and `Val` wrappers are `leaf` types, and can not contain other `leaf` types.
+///
+/// This is to keep the implementations of this trait simple, and to ultimately depend on the `TypeInfo` trait for the actual type information.
+#[derive(Debug, Clone)]
+pub enum ThroughTypeInfo {
+    /// A wrapper around a typed type, which itself is not a `Typed` type.
+    UntypedWrapper {
+        /// The type information of the inner type.
+        through_type: &'static TypeInfo,
+        /// The type id of the wrapper type.
+        wrapper_type_id: TypeId,
+        /// The name of the wrapper type.
+        wrapper_name: &'static str,
+    },
+    /// A wrapper around a through typed type, which itself is also a `Typed` type.
+    TypedWrapper(TypedWrapperKind),
+    /// an actual type info
+    TypeInfo(&'static TypeInfo),
+}
+
+/// The kind of typed wrapper.
+#[derive(Debug, Clone)]
+pub enum TypedWrapperKind {
+    /// Wraps a `Vec` of a through typed type.
+    Vec(Box<ThroughTypeInfo>),
+    /// Wraps a `HashMap` of a through typed type.
+    HashMap(Box<ThroughTypeInfo>, Box<ThroughTypeInfo>),
+    /// Wraps a `Result` of a through typed type.
+    Array(Box<ThroughTypeInfo>, usize),
+    /// Wraps an `Option` of a through typed type.
+    Option(Box<ThroughTypeInfo>),
+    /// Wraps a `Result` of a through typed type.
+    InteropResult(Box<ThroughTypeInfo>),
+    /// Wraps a tuple of through typed types.
+    Tuple(Vec<ThroughTypeInfo>),
+}
+
+/// A trait for types that can be converted to a [`ThroughTypeInfo`].
+pub trait TypedThrough {
+    /// Get the [`ThroughTypeInfo`] for the type.
+    fn through_type_info() -> ThroughTypeInfo;
+}
+
+impl<T: Typed> TypedThrough for Ref<'_, T> {
+    fn through_type_info() -> ThroughTypeInfo {
+        ThroughTypeInfo::UntypedWrapper {
+            through_type: T::type_info(),
+            wrapper_type_id: TypeId::of::<Ref<T>>(),
+            wrapper_name: "Ref",
+        }
+    }
+}
+
+impl<T: Typed> TypedThrough for Mut<'_, T> {
+    fn through_type_info() -> ThroughTypeInfo {
+        ThroughTypeInfo::UntypedWrapper {
+            through_type: T::type_info(),
+            wrapper_type_id: TypeId::of::<Mut<T>>(),
+            wrapper_name: "Mut",
+        }
+    }
+}
+
+impl<T: Typed> TypedThrough for Val<T> {
+    fn through_type_info() -> ThroughTypeInfo {
+        ThroughTypeInfo::UntypedWrapper {
+            through_type: T::type_info(),
+            wrapper_type_id: TypeId::of::<Val<T>>(),
+            wrapper_name: "Val",
+        }
+    }
+}
+
+impl<T: TypedThrough> TypedThrough for Vec<T> {
+    fn through_type_info() -> ThroughTypeInfo {
+        ThroughTypeInfo::TypedWrapper(TypedWrapperKind::Vec(Box::new(T::through_type_info())))
+    }
+}
+
+impl<K: TypedThrough, V: TypedThrough> TypedThrough for std::collections::HashMap<K, V> {
+    fn through_type_info() -> ThroughTypeInfo {
+        ThroughTypeInfo::TypedWrapper(TypedWrapperKind::HashMap(
+            Box::new(K::through_type_info()),
+            Box::new(V::through_type_info()),
+        ))
+    }
+}
+
+impl<T: TypedThrough> TypedThrough for Result<T, InteropError> {
+    fn through_type_info() -> ThroughTypeInfo {
+        ThroughTypeInfo::TypedWrapper(TypedWrapperKind::InteropResult(Box::new(
+            T::through_type_info(),
+        )))
+    }
+}
+
+impl<T: TypedThrough, const N: usize> TypedThrough for [T; N] {
+    fn through_type_info() -> ThroughTypeInfo {
+        ThroughTypeInfo::TypedWrapper(TypedWrapperKind::Array(Box::new(T::through_type_info()), N))
+    }
+}
+
+impl<T: TypedThrough> TypedThrough for Option<T> {
+    fn through_type_info() -> ThroughTypeInfo {
+        ThroughTypeInfo::TypedWrapper(TypedWrapperKind::Option(Box::new(T::through_type_info())))
+    }
+}
+
+macro_rules! impl_through_typed {
+    ($($ty:ty),*) => {
+        $(
+            impl $crate::docgen::typed_through::TypedThrough for $ty {
+                fn through_type_info() -> $crate::docgen::typed_through::ThroughTypeInfo {
+                    $crate::docgen::typed_through::ThroughTypeInfo::TypeInfo(<$ty as bevy::reflect::Typed>::type_info())
+                }
+            }
+        )*
+    };
+}
+
+impl_through_typed!(
+    FunctionCallContext,
+    ReflectReference,
+    DynamicScriptFunctionMut,
+    DynamicScriptFunction,
+    ScriptValue,
+    bool,
+    i8,
+    i16,
+    i32,
+    i64,
+    i128,
+    u8,
+    u16,
+    u32,
+    u64,
+    u128,
+    f32,
+    f64,
+    usize,
+    isize,
+    String,
+    PathBuf,
+    OsString,
+    char,
+    &'static str
+);
+
+macro_rules! impl_through_typed_tuple {
+    ($($ty:ident),*) => {
+        impl<$($ty: TypedThrough),*> TypedThrough for ($($ty,)*) {
+            fn through_type_info() -> ThroughTypeInfo {
+                ThroughTypeInfo::TypedWrapper(TypedWrapperKind::Tuple(vec![$($ty::through_type_info()),*]))
+            }
+        }
+    };
+}
+
+bevy::utils::all_tuples!(impl_through_typed_tuple, 0, 13, T);
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    fn assert_type_info_is_through<T: Typed + TypedThrough>() {
+        let type_info = T::type_info();
+        let through_type_info = T::through_type_info();
+
+        match through_type_info {
+            ThroughTypeInfo::TypeInfo(info) => {
+                assert_eq!(info.type_id(), type_info.type_id());
+                assert_eq!(info.type_path(), type_info.type_path());
+            }
+            _ => panic!("Expected ThroughTypeInfo::TypeInfo"),
+        }
+    }
+
+    #[test]
+    fn test_typed_through_primitives() {
+        assert_type_info_is_through::<bool>();
+        assert_type_info_is_through::<i8>();
+        assert_type_info_is_through::<i16>();
+        assert_type_info_is_through::<i32>();
+        assert_type_info_is_through::<i64>();
+        assert_type_info_is_through::<i128>();
+        assert_type_info_is_through::<u8>();
+        assert_type_info_is_through::<u16>();
+        assert_type_info_is_through::<u32>();
+        assert_type_info_is_through::<u64>();
+        assert_type_info_is_through::<u128>();
+        assert_type_info_is_through::<f32>();
+        assert_type_info_is_through::<f64>();
+        assert_type_info_is_through::<usize>();
+        assert_type_info_is_through::<isize>();
+        assert_type_info_is_through::<String>();
+        assert_type_info_is_through::<PathBuf>();
+        assert_type_info_is_through::<OsString>();
+        assert_type_info_is_through::<char>();
+        assert_type_info_is_through::<ReflectReference>();
+        assert_type_info_is_through::<&'static str>();
+    }
+
+    #[test]
+    fn test_typed_wrapper_outer_variant_matches() {
+        assert!(matches!(
+            Vec::<i32>::through_type_info(),
+            ThroughTypeInfo::TypedWrapper(TypedWrapperKind::Vec(..))
+        ));
+
+        assert!(matches!(
+            std::collections::HashMap::<i32, f32>::through_type_info(),
+            ThroughTypeInfo::TypedWrapper(TypedWrapperKind::HashMap(..))
+        ));
+
+        assert!(matches!(
+            Result::<i32, InteropError>::through_type_info(),
+            ThroughTypeInfo::TypedWrapper(TypedWrapperKind::InteropResult(..))
+        ));
+
+        assert!(matches!(
+            <[i32; 3]>::through_type_info(),
+            ThroughTypeInfo::TypedWrapper(TypedWrapperKind::Array(..))
+        ));
+
+        assert!(matches!(
+            Option::<i32>::through_type_info(),
+            ThroughTypeInfo::TypedWrapper(TypedWrapperKind::Option(..))
+        ));
+
+        assert!(matches!(
+            <(i32, f32)>::through_type_info(),
+            ThroughTypeInfo::TypedWrapper(TypedWrapperKind::Tuple(..))
+        ));
+    }
+}


### PR DESCRIPTION
Adds inlined type information on each argument and return type for later use in docgen