### PR TITLE
fix: `tracy` compile errors and add tracy buid to CI

### DIFF
--- a/crates/bevy_mod_scripting_core/src/bindings/function/script_function.rs
+++ b/crates/bevy_mod_scripting_core/src/bindings/function/script_function.rs
@@ -99,7 +99,7 @@ impl DynamicScriptFunction {
         args: I,
         context: FunctionCallContext,
     ) -> Result<ScriptValue, InteropError> {
-        profiling::scope!("Dynamic Call ", self.name().clone());
+        profiling::scope!("Dynamic Call ", self.name());
         let args = args.into_iter().collect::<VecDeque<_>>();
         // should we be inlining call errors into the return value?
         let return_val = (self.func)(context, args);
@@ -155,7 +155,7 @@ impl DynamicScriptFunctionMut {
         args: I,
         context: FunctionCallContext,
     ) -> Result<ScriptValue, InteropError> {
-        profiling::scope!("Dynamic Call Mut", self.name().clone());
+        profiling::scope!("Dynamic Call Mut", self.name());
         let args = args.into_iter().collect::<VecDeque<_>>();
         // should we be inlining call errors into the return value?
         let mut write = self.func.write();

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -114,11 +114,12 @@ struct Features(HashSet<Feature>);
 
 impl Default for Features {
     fn default() -> Self {
-        // should be kept up to date with the default feature + lua54
+        // should be kept up to date with the default feature + lua54 on top of anything that is handy to run locally every time
         Features::new(vec![
             Feature::Lua54,
             Feature::CoreFunctions,
             Feature::BevyBindings,
+            Feature::Tracy,
         ])
     }
 }

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -49,6 +49,10 @@ enum Feature {
     Rhai,
     // Rune
     // Rune,
+
+    // Profiling
+    #[strum(serialize = "profiling/profile-with-tracy")]
+    Tracy,
 }
 
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, strum::EnumIter)]
@@ -97,7 +101,8 @@ impl IntoFeatureGroup for Feature {
             Feature::MluaAsync
             | Feature::MluaMacros
             | Feature::MluaSerialize
-            | Feature::UnsafeLuaModules => FeatureGroup::ForExternalCrate,
+            | Feature::UnsafeLuaModules
+            | Feature::Tracy => FeatureGroup::ForExternalCrate,
             Feature::BevyBindings | Feature::CoreFunctions => FeatureGroup::BMSFeature,
             // don't use wildcard here, we want to be explicit
         }


### PR DESCRIPTION
Adds tracy features by default to local as well as CI checks and fixes the current build errors.

Fixes #275 