### PR TITLE
feat: add `construct` global for constructing arbitrary types & `Union` type

### DIFF
--- a/crates/bevy_mod_scripting_core/Cargo.toml
+++ b/crates/bevy_mod_scripting_core/Cargo.toml
@@ -48,6 +48,7 @@ bevy_mod_scripting_derive = { workspace = true }
 [dev-dependencies]
 test_utils = { workspace = true }
 tokio = { version = "1", features = ["rt", "macros"] }
+pretty_assertions = "1.4"
 
 [lints]
 workspace = true

--- a/crates/bevy_mod_scripting_core/src/bindings/function/arg_meta.rs
+++ b/crates/bevy_mod_scripting_core/src/bindings/function/arg_meta.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 
 use super::{
-    from::{FromScript, Mut, Ref, Val},
+    from::{FromScript, Mut, Ref, Union, Val},
     into::IntoScript,
     script_function::{DynamicScriptFunction, DynamicScriptFunctionMut, FunctionCallContext},
     type_dependencies::GetTypeDependencies,
@@ -72,6 +72,7 @@ impl_arg_info!(
     &'static str
 );
 
+impl<T1, T2> ArgMeta for Union<T1, T2> {}
 impl<T> ArgMeta for Val<T> {}
 impl<T> ArgMeta for Ref<'_, T> {}
 impl<T> ArgMeta for Mut<'_, T> {}

--- a/crates/bevy_mod_scripting_core/src/bindings/function/mod.rs
+++ b/crates/bevy_mod_scripting_core/src/bindings/function/mod.rs
@@ -18,7 +18,7 @@ mod test {
     use crate::{
         bindings::{
             function::{
-                from::{Ref, Val},
+                from::{Ref, Union, Val},
                 namespace::IntoNamespace,
                 script_function::AppScriptFunctionRegistry,
             },
@@ -109,6 +109,8 @@ mod test {
 
     #[test]
     fn composites_are_valid_args() {
+        test_is_valid_arg::<Union<usize, usize>>();
+
         fn test_val<T>()
         where
             T: ScriptArgument + ScriptReturn,

--- a/crates/bevy_mod_scripting_core/src/bindings/function/type_dependencies.rs
+++ b/crates/bevy_mod_scripting_core/src/bindings/function/type_dependencies.rs
@@ -1,7 +1,7 @@
 //! This module contains the [`GetTypeDependencies`] trait and its implementations for various types.
 
 use super::{
-    from::{Mut, Ref, Val},
+    from::{Mut, Ref, Union, Val},
     script_function::FunctionCallContext,
 };
 use crate::{
@@ -87,6 +87,13 @@ recursive_type_dependencies!(
     (Vec<T>  where T: GetTypeRegistration;FromReflect;Typed => with Self),
     (HashMap<K,V> where K: GetTypeRegistration;FromReflect;Typed;Hash;Eq, V: GetTypeRegistration;FromReflect;Typed => with Self)
 );
+
+impl<T1: GetTypeDependencies, T2: GetTypeDependencies> GetTypeDependencies for Union<T1, T2> {
+    fn register_type_dependencies(registry: &mut TypeRegistry) {
+        T1::register_type_dependencies(registry);
+        T2::register_type_dependencies(registry);
+    }
+}
 
 bevy::utils::all_tuples!(register_tuple_dependencies, 1, 14, T);
 

--- a/crates/bevy_mod_scripting_core/src/bindings/query.rs
+++ b/crates/bevy_mod_scripting_core/src/bindings/query.rs
@@ -80,6 +80,11 @@ impl ScriptResourceRegistration {
     pub fn type_registration(&self) -> &ScriptTypeRegistration {
         &self.registration
     }
+
+    /// Convert to a generic [`ScriptTypeRegistration`] ditching the resource information.
+    pub fn into_type_registration(self) -> ScriptTypeRegistration {
+        self.registration
+    }
 }
 
 impl ScriptComponentRegistration {
@@ -100,6 +105,11 @@ impl ScriptComponentRegistration {
     /// Returns the [`ScriptTypeRegistration`] for this type.
     pub fn type_registration(&self) -> &ScriptTypeRegistration {
         &self.registration
+    }
+
+    /// Convert to a generic [`ScriptTypeRegistration`] ditching the component information.
+    pub fn into_type_registration(self) -> ScriptTypeRegistration {
+        self.registration
     }
 }
 

--- a/crates/bevy_mod_scripting_core/src/bindings/reference.rs
+++ b/crates/bevy_mod_scripting_core/src/bindings/reference.rs
@@ -61,6 +61,16 @@ pub enum TypeIdSource {
 }
 #[profiling::all_functions]
 impl ReflectReference {
+    /// If this points to a variant of an enum, returns the name of the variant.
+    pub fn variant_name(&self, world: WorldGuard) -> Result<Option<String>, InteropError> {
+        self.with_reflect(world, |s| {
+            s.reflect_ref()
+                .as_enum()
+                .ok()
+                .map(|enum_ref| enum_ref.variant_name().to_owned())
+        })
+    }
+
     /// Creates a new infinite iterator. This iterator will keep returning the next element reference forever.
     pub fn into_iter_infinite(self) -> ReflectRefIter {
         ReflectRefIter::new_indexed(self)

--- a/crates/bevy_mod_scripting_core/src/docgen/typed_through.rs
+++ b/crates/bevy_mod_scripting_core/src/docgen/typed_through.rs
@@ -8,7 +8,7 @@ use bevy::reflect::{TypeInfo, Typed};
 use crate::{
     bindings::{
         function::{
-            from::{Mut, Ref, Val},
+            from::{Mut, Ref, Union, Val},
             script_function::{
                 DynamicScriptFunction, DynamicScriptFunctionMut, FunctionCallContext,
             },
@@ -59,6 +59,8 @@ pub enum UntypedWrapperKind {
 /// The kind of typed wrapper.
 #[derive(Debug, Clone)]
 pub enum TypedWrapperKind {
+    /// A union of many possible types
+    Union(Vec<ThroughTypeInfo>),
     /// Wraps a `Vec` of a through typed type.
     Vec(Box<ThroughTypeInfo>),
     /// Wraps a `HashMap` of a through typed type.
@@ -77,6 +79,15 @@ pub enum TypedWrapperKind {
 pub trait TypedThrough {
     /// Get the [`ThroughTypeInfo`] for the type.
     fn through_type_info() -> ThroughTypeInfo;
+}
+
+impl<T1: TypedThrough, T2: TypedThrough> TypedThrough for Union<T1, T2> {
+    fn through_type_info() -> ThroughTypeInfo {
+        ThroughTypeInfo::TypedWrapper(TypedWrapperKind::Union(vec![
+            T1::through_type_info(),
+            T2::through_type_info(),
+        ]))
+    }
 }
 
 impl<T: Typed> TypedThrough for Ref<'_, T> {

--- a/crates/ladfile/src/lib.rs
+++ b/crates/ladfile/src/lib.rs
@@ -176,6 +176,8 @@ pub enum LadArgumentKind {
     Array(Box<LadArgumentKind>, usize),
     /// A primitive type, implementing `IntoScript` and `FromScript` natively in BMS.
     Primitive(LadBMSPrimitiveKind),
+    /// A union of two or more types
+    Union(Vec<LadArgumentKind>),
     /// An arbitrary type which is either unsupported, doesn't contain type information, or is generally unknown.
     ///
     /// This will be the variant used for external primitives as well.
@@ -248,6 +250,13 @@ pub trait ArgumentVisitor {
         self.visit_lad_bms_primitive_kind(primitive_kind);
     }
 
+    /// traverse a union of arguments, by default calls `visit` on each argument
+    fn walk_union(&mut self, inner: &[LadArgumentKind]) {
+        for arg in inner {
+            self.visit(arg);
+        }
+    }
+
     /// traverse an unknown argument, by default calls `visit` on the type id
     fn walk_unknown(&mut self, type_id: &LadTypeId) {
         self.visit_lad_type_id(type_id);
@@ -270,6 +279,7 @@ pub trait ArgumentVisitor {
             LadArgumentKind::Tuple(inner) => self.walk_tuple(inner),
             LadArgumentKind::Array(inner, size) => self.walk_array(inner, *size),
             LadArgumentKind::Primitive(primitive_kind) => self.walk_primitive(primitive_kind),
+            LadArgumentKind::Union(inner) => self.walk_union(inner),
             LadArgumentKind::Unknown(type_id) => self.walk_unknown(type_id),
         }
     }

--- a/crates/ladfile_builder/src/lib.rs
+++ b/crates/ladfile_builder/src/lib.rs
@@ -581,6 +581,14 @@ impl<'t> LadFileBuilder<'t> {
                         })
                         .collect(),
                 ),
+                TypedWrapperKind::Union(through_type_infos) => LadArgumentKind::Union(
+                    through_type_infos
+                        .iter()
+                        .map(|through_type_info| {
+                            self.lad_argument_type_from_through_type(through_type_info)
+                        })
+                        .collect(),
+                ),
             },
             ThroughTypeInfo::TypeInfo(type_info) => {
                 match primitive_from_type_id(type_info.type_id()) {

--- a/crates/languages/bevy_mod_scripting_lua/tests/data/construct/construct_enum.lua
+++ b/crates/languages/bevy_mod_scripting_lua/tests/data/construct/construct_enum.lua
@@ -1,0 +1,27 @@
+local type = world.get_type_by_name("SimpleEnum")
+
+-- Struct Variant
+local constructed = construct(type, {
+    variant = "Struct",
+    foo = 123
+})
+
+assert(constructed:variant_name() == "Struct", "Value was constructed incorrectly, expected constructed.variant to be Struct but got " .. constructed:variant_name())
+assert(constructed.foo == 123, "Value was constructed incorrectly, expected constructed.foo to be 123 but got " .. constructed.foo)
+
+
+-- TupleStruct Variant
+local constructed = construct(type, {
+    variant = "TupleStruct",
+    _1 = 123
+})
+
+assert(constructed:variant_name() == "TupleStruct", "Value was constructed incorrectly, expected constructed.variant to be TupleStruct but got " .. constructed:variant_name())
+assert(constructed._1 == 123, "Value was constructed incorrectly, expected constructed._1 to be 123 but got " .. constructed._1)
+
+-- Unit Variant
+local constructed = construct(type, {
+    variant = "Unit"
+})
+
+assert(constructed:variant_name() == "Unit", "Value was constructed incorrectly, expected constructed.variant to be Unit but got " .. constructed:variant_name())

--- a/crates/languages/bevy_mod_scripting_lua/tests/data/construct/construct_struct.lua
+++ b/crates/languages/bevy_mod_scripting_lua/tests/data/construct/construct_struct.lua
@@ -1,0 +1,6 @@
+local type = world.get_type_by_name("SimpleStruct")
+local constructed = construct(type, {
+    foo = 123
+})
+
+assert(constructed.foo == 123, "Value was constructed incorrectly, expected constructed.foo to be 123 but got " .. constructed.foo)

--- a/crates/languages/bevy_mod_scripting_lua/tests/data/construct/construct_tuple_struct.lua
+++ b/crates/languages/bevy_mod_scripting_lua/tests/data/construct/construct_tuple_struct.lua
@@ -1,0 +1,8 @@
+local type = world.get_type_by_name("SimpleTupleStruct")
+local constructed = construct(type, {
+    _1 = 123
+})
+
+print(constructed:display_value())
+
+assert(constructed._1 == 123, "Value was constructed incorrectly, expected constructed.foo to be 123 but got " .. constructed._1)

--- a/crates/languages/bevy_mod_scripting_rhai/tests/data/construct/simple_enum.rhai
+++ b/crates/languages/bevy_mod_scripting_rhai/tests/data/construct/simple_enum.rhai
@@ -1,0 +1,18 @@
+let type = world.get_type_by_name.call("SimpleEnum");
+
+// Struct Variant
+let constructed = construct.call(type, #{ variant: "Struct", foo: 123 });
+
+assert(constructed.variant_name.call() == "Struct", "Value was constructed incorrectly, expected constructed.variant to be Struct but got " + constructed.variant_name.call());
+assert(constructed.foo == 123, "Value was constructed incorrectly, expected constructed.foo to be 123 but got " + constructed.foo);
+
+// TupleStruct Variant
+constructed = construct.call(type, #{ variant: "TupleStruct", "_0": 123 });
+
+assert(constructed.variant_name.call() == "TupleStruct", "Value was constructed incorrectly, expected constructed.variant to be TupleStruct but got " + constructed.variant_name.call());
+assert(constructed["_0"] == 123, "Value was constructed incorrectly, expected constructed._0 to be 123 but got " + constructed["_0"]);
+
+// Unit Variant
+constructed = construct.call(type, #{ variant: "Unit" });
+
+assert(constructed.variant_name.call() == "Unit", "Value was constructed incorrectly, expected constructed.variant to be Unit but got " + constructed.variant_name.call());

--- a/crates/languages/bevy_mod_scripting_rhai/tests/data/construct/simple_struct.rhai
+++ b/crates/languages/bevy_mod_scripting_rhai/tests/data/construct/simple_struct.rhai
@@ -1,0 +1,4 @@
+let type = world.get_type_by_name.call("SimpleStruct");
+let constructed = construct.call(type, #{ foo: 123 });
+
+assert(constructed.foo == 123, "Value was constructed incorrectly, expected constructed.foo to be 123 but got " + constructed.foo);

--- a/crates/languages/bevy_mod_scripting_rhai/tests/data/construct/simple_tuple_struct.rhai
+++ b/crates/languages/bevy_mod_scripting_rhai/tests/data/construct/simple_tuple_struct.rhai
@@ -1,0 +1,4 @@
+let type = world.get_type_by_name.call("SimpleTupleStruct");
+let constructed = construct.call(type, #{ "_0": 123 });
+
+assert(constructed["_0"] == 123, "Value was constructed incorrectly, expected constructed.foo to be 123 but got " + constructed["_0"]);

--- a/crates/testing_crates/test_utils/src/test_data.rs
+++ b/crates/testing_crates/test_utils/src/test_data.rs
@@ -139,6 +139,45 @@ impl TestResourceWithVariousFields {
     }
 }
 
+#[derive(Component, Reflect, PartialEq, Eq, Debug, Default)]
+#[reflect(Component, Default)]
+pub struct SimpleStruct {
+    pub foo: usize,
+}
+
+impl SimpleStruct {
+    pub fn init() -> Self {
+        Self { foo: 42 }
+    }
+}
+
+#[derive(Component, Reflect, PartialEq, Eq, Debug, Default)]
+#[reflect(Component, Default)]
+pub struct SimpleTupleStruct(pub usize);
+
+impl SimpleTupleStruct {
+    pub fn init() -> Self {
+        Self(42)
+    }
+}
+
+#[derive(Component, Reflect, PartialEq, Eq, Debug, Default)]
+#[reflect(Component, Default)]
+pub enum SimpleEnum {
+    Struct {
+        foo: usize,
+    },
+    TupleStruct(usize),
+    #[default]
+    Unit,
+}
+
+impl SimpleEnum {
+    pub fn init() -> Self {
+        Self::Struct { foo: 42 }
+    }
+}
+
 pub(crate) const TEST_COMPONENT_ID_START: usize = 20;
 pub(crate) const TEST_ENTITY_ID_START: u32 = 0;
 
@@ -182,16 +221,16 @@ macro_rules! impl_test_component_ids {
                 world.register_component::<$comp_type>();
                 registry.register::<$comp_type>();
                 let registered_id = world.component_id::<$comp_type>().unwrap().index();
-                assert_eq!(registered_id, TEST_COMPONENT_ID_START + $comp_id, "Test setup failed. Did you register components before running setup_world?");
+                assert_eq!(registered_id, TEST_COMPONENT_ID_START + $comp_id, "Test setup failed. Did you register components before running setup_world?: {}", stringify!($comp_type));
                 let entity = world.spawn(<$comp_type>::init()).id();
-                assert_eq!(entity.index(), TEST_ENTITY_ID_START + $comp_id, "Test setup failed. Did you spawn entities before running setup_world?");
-                assert_eq!(entity.generation(), 1, "Test setup failed. Did you spawn entities before running setup_world?");
+                assert_eq!(entity.index(), TEST_ENTITY_ID_START + $comp_id, "Test setup failed. Did you spawn entities before running setup_world?: {}", stringify!($comp_type));
+                assert_eq!(entity.generation(), 1, "Test setup failed. Did you spawn entities before running setup_world?: {}", stringify!($comp_type));
             )*
             $(
                 world.insert_resource::<$res_type>(<$res_type>::init());
                 registry.register::<$res_type>();
                 let registered_id = world.resource_id::<$res_type>().unwrap().index();
-                assert_eq!(registered_id, TEST_COMPONENT_ID_START + $res_id, "Test setup failed. Did you register components before running setup_world?");
+                assert_eq!(registered_id, TEST_COMPONENT_ID_START + $res_id, "Test setup failed. Did you register components before running setup_world?: {}", stringify!($res_type));
             )*
         }
 
@@ -216,12 +255,15 @@ impl_test_component_ids!(
         CompWithFromWorld => 1,
         CompWithDefault => 2,
         CompWithDefaultAndComponentData => 3,
-        CompWithFromWorldAndComponentData => 4
+        CompWithFromWorldAndComponentData => 4,
+        SimpleStruct => 5,
+        SimpleTupleStruct => 6,
+        SimpleEnum => 7,
     ],
     [
-        TestResource => 5,
-        ResourceWithDefault => 6,
-        TestResourceWithVariousFields => 7,
+        TestResource => 8,
+        ResourceWithDefault => 9,
+        TestResourceWithVariousFields => 10,
     ]
 );
 


### PR DESCRIPTION

Makes this possible:
```lua
local type = world.get_type_by_name("SimpleEnum")

-- Struct Variant
local constructed = construct(type, {
    variant = "Struct",
    foo = 123
})

assert(constructed:variant_name() == "Struct", "Value was constructed incorrectly, expected constructed.variant to be Struct but got " .. constructed:variant_name())
assert(constructed.foo == 123, "Value was constructed incorrectly, expected constructed.foo to be 123 but got " .. constructed.foo)


-- TupleStruct Variant
local constructed = construct(type, {
    variant = "TupleStruct",
    _1 = 123
})

assert(constructed:variant_name() == "TupleStruct", "Value was constructed incorrectly, expected constructed.variant to be TupleStruct but got " .. constructed:variant_name())
assert(constructed._1 == 123, "Value was constructed incorrectly, expected constructed._1 to be 123 but got " .. constructed._1)

-- Unit Variant
local constructed = construct(type, {
    variant = "Unit"
})

assert(constructed:variant_name() == "Unit", "Value was constructed incorrectly, expected constructed.variant to be Unit but got " .. constructed:variant_name())
```