### PR TITLE
feat: Allow trailing comma in callback_labels.

### DIFF
--- a/crates/bevy_mod_scripting_core/src/event.rs
+++ b/crates/bevy_mod_scripting_core/src/event.rs
@@ -57,7 +57,7 @@ impl CallbackLabel {
 #[macro_export]
 /// Creates a set of callback labels
 macro_rules! callback_labels {
-    ($($name:ident => $label:expr),*) => {
+    ($($name:ident => $label:expr),* $(,)?) => {
 
         $(
             #[doc = "A callback label for the event: "]
@@ -74,7 +74,7 @@ macro_rules! callback_labels {
 
 callback_labels!(
     OnScriptLoaded => "on_script_loaded",
-    OnScriptUnloaded => "on_script_unloaded"
+    OnScriptUnloaded => "on_script_unloaded",
 );
 
 /// A trait for types that can be converted into a callback label


### PR DESCRIPTION
Love seeing all your releases and progress of late! This is tiny thing, it just permits a trailing comma when defining callback labels using the macro.