### PR TITLE
feat: add test for construct using unit struct

### DIFF
--- a/crates/languages/bevy_mod_scripting_lua/tests/data/construct/construct_unit_struct.lua
+++ b/crates/languages/bevy_mod_scripting_lua/tests/data/construct/construct_unit_struct.lua
@@ -1,0 +1,4 @@
+local type = world.get_type_by_name("UnitStruct")
+local constructed = construct(type, {})
+
+assert(constructed ~= nil, "Value was not constructed")

--- a/crates/languages/bevy_mod_scripting_lua/tests/data/construct/construct_unit_struct.lua
+++ b/crates/languages/bevy_mod_scripting_lua/tests/data/construct/construct_unit_struct.lua
@@ -1,4 +1,4 @@
 local type = world.get_type_by_name("UnitStruct")
-local constructed = construct(type, map({}))
+local constructed = construct(type, {})
 
 assert(constructed ~= nil, "Value was not constructed")

--- a/crates/languages/bevy_mod_scripting_lua/tests/data/construct/construct_unit_struct.lua
+++ b/crates/languages/bevy_mod_scripting_lua/tests/data/construct/construct_unit_struct.lua
@@ -1,4 +1,4 @@
 local type = world.get_type_by_name("UnitStruct")
-local constructed = construct(type, {})
+local constructed = construct(type, map({}))
 
 assert(constructed ~= nil, "Value was not constructed")

--- a/crates/languages/bevy_mod_scripting_rhai/tests/data/construct/unit_struct.rhai
+++ b/crates/languages/bevy_mod_scripting_rhai/tests/data/construct/unit_struct.rhai
@@ -1,2 +1,2 @@
 let type = world.get_type_by_name.call("UnitStruct");
-let constructed = construct.call(type, map.call(#{}));
+let constructed = construct.call(type, #{});

--- a/crates/languages/bevy_mod_scripting_rhai/tests/data/construct/unit_struct.rhai
+++ b/crates/languages/bevy_mod_scripting_rhai/tests/data/construct/unit_struct.rhai
@@ -1,0 +1,2 @@
+let type = world.get_type_by_name.call("UnitStruct");
+let constructed = construct.call(type, map.call(#{}));

--- a/crates/testing_crates/test_utils/src/test_data.rs
+++ b/crates/testing_crates/test_utils/src/test_data.rs
@@ -147,6 +147,16 @@ impl TestResourceWithVariousFields {
 
 #[derive(Component, Reflect, PartialEq, Eq, Debug, Default)]
 #[reflect(Component, Default)]
+pub struct UnitStruct;
+
+impl UnitStruct {
+    pub fn init() -> Self {
+        Self
+    }
+}
+
+#[derive(Component, Reflect, PartialEq, Eq, Debug, Default)]
+#[reflect(Component, Default)]
 pub struct SimpleStruct {
     pub foo: usize,
 }
@@ -262,14 +272,15 @@ impl_test_component_ids!(
         CompWithDefault => 2,
         CompWithDefaultAndComponentData => 3,
         CompWithFromWorldAndComponentData => 4,
-        SimpleStruct => 5,
-        SimpleTupleStruct => 6,
-        SimpleEnum => 7,
+        UnitStruct => 5,
+        SimpleStruct => 6,
+        SimpleTupleStruct => 7,
+        SimpleEnum => 8,
     ],
     [
-        TestResource => 8,
-        ResourceWithDefault => 9,
-        TestResourceWithVariousFields => 10,
+        TestResource => 9,
+        ResourceWithDefault => 10,
+        TestResourceWithVariousFields => 11,
     ]
 );
 


### PR DESCRIPTION
Pushing this PR up so we can document how to construct unit structs. The first commit of this PR will fail with:

```
---- script_test - lua - /construct/construct_unit_struct.lua ----
error: Error in function construct : Error converting argument 2: Value mismatch, expected: std::collections::HashMap<alloc::string::String, bevy_mod_scripting_core::bindings::script_value::ScriptValue, std::collections::hash_map::RandomState>, got: [].
Context:
stack traceback:
        [C]: in function 'construct'
        [string "crates/languages/bevy_mod_scripting_lua/src/l..."]:2: in main chunk
```

Not sure how to get this to work without passing dummy values like this:

```lua
local type = world.get_type_by_name("UnitStruct")
local constructed = construct(type, {
    dummy = true
})

assert(constructed ~= nil, "Value was not constructed")
```

@makspll feel free to push to my PR if you have a fix. Hopefully this test documents this for future users.