### PR TITLE
feat: create global `map` for allowing empty hashmap construction

### DIFF
--- a/crates/bevy_mod_scripting_functions/src/core.rs
+++ b/crates/bevy_mod_scripting_functions/src/core.rs
@@ -656,6 +656,25 @@ impl GlobalNamespace {
             &mut allocator,
         ))
     }
+
+    /// Constructs a hash map. Useful for languages which do not make the distinction between lists and dictionaries.
+    ///
+    /// Arguments:
+    /// * `map_or_list`: The list or map to convert to a hash map.
+    /// Returns:
+    /// * `hashMap`: The converted hash map
+    fn map(
+        map_or_list: Union<HashMap<String, ScriptValue>, Vec<ScriptValue>>,
+    ) -> HashMap<String, ScriptValue> {
+        match map_or_list.into_left() {
+            Ok(map) => map,
+            Err(list) => list
+                .into_iter()
+                .enumerate()
+                .map(|(k, v)| (k.to_string(), v))
+                .collect(),
+        }
+    }
 }
 
 pub fn register_core_functions(app: &mut App) {


### PR DESCRIPTION
Should allow:
```lua
local map = map({})
```
i.e. lua cannot make the distinction between an empty table and hashmap normally

Addresses https://github.com/makspll/bevy_mod_scripting/pull/328