### PR TITLE
fix: remove `map` global and instead allow hashmap `FromScript` from list of tuples

### DIFF
--- a/crates/bevy_mod_scripting_core/src/bindings/function/mod.rs
+++ b/crates/bevy_mod_scripting_core/src/bindings/function/mod.rs
@@ -151,9 +151,9 @@ mod test {
             for<'a> T::This<'a>: Into<T>,
         {
             test_is_valid_arg_and_return::<()>();
-            test_is_valid_return::<(T,)>();
-            test_is_valid_return::<(T, T)>();
-            test_is_valid_return::<(T, T, T, T, T, T, T, T, T, T)>();
+            test_is_valid_arg_and_return::<(T,)>();
+            test_is_valid_arg_and_return::<(T, T)>();
+            test_is_valid_arg_and_return::<(T, T, T, T, T, T, T, T, T, T)>();
         }
 
         fn test_option<T>()

--- a/crates/bevy_mod_scripting_core/src/bindings/function/script_function.rs
+++ b/crates/bevy_mod_scripting_core/src/bindings/function/script_function.rs
@@ -530,9 +530,11 @@ impl ScriptFunctionRegistry {
 }
 
 macro_rules! count {
-    () => (0usize);
-    ( $x:tt $($xs:tt)* ) => (1usize + count!($($xs)*));
+        () => (0usize);
+        ( $x:tt $($xs:tt)* ) => (1usize + $crate::bindings::function::script_function::count!($($xs)*));
 }
+
+pub(crate) use count;
 
 macro_rules! impl_script_function {
 

--- a/crates/bevy_mod_scripting_functions/src/core.rs
+++ b/crates/bevy_mod_scripting_functions/src/core.rs
@@ -656,25 +656,6 @@ impl GlobalNamespace {
             &mut allocator,
         ))
     }
-
-    /// Constructs a hash map. Useful for languages which do not make the distinction between lists and dictionaries.
-    ///
-    /// Arguments:
-    /// * `map_or_list`: The list or map to convert to a hash map.
-    /// Returns:
-    /// * `hashMap`: The converted hash map
-    fn map(
-        map_or_list: Union<HashMap<String, ScriptValue>, Vec<ScriptValue>>,
-    ) -> HashMap<String, ScriptValue> {
-        match map_or_list.into_left() {
-            Ok(map) => map,
-            Err(list) => list
-                .into_iter()
-                .enumerate()
-                .map(|(k, v)| (k.to_string(), v))
-                .collect(),
-        }
-    }
 }
 
 pub fn register_core_functions(app: &mut App) {


### PR DESCRIPTION
The fix in #329 didn't fully work as the returned value would STILL be just a map, instead a more geneorus `FromScript` implementation should do the trick, without necessitating a new function call