### PR TITLE
docs: add links to examples in the book

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,25 @@
+# Summary
+- enter PR summary here
+- what did you change
+- why did you do it this way?
+- Are there alternative ways we need to keep in mind?
+
+## Testing (Read & Delete Me)
+- Did you write tests to cover new or modified behavior?
+- These are not necessary, but very welcome
+- I am always happy to receive any PR's, but adding tests makes it easier for me to merge them!
+
+## Conventional PR Titles (Read & Delete me)
+- This crate uses `release-plz` to manage our deploys
+- A CI check will verify your PR title to make sure it uses a valid conventional prefix like:
+    - `feat: {title}` - corresponds to `Added` heading in changelog, backwards compatibile changes
+    - `fix: {title}` - corresponds to `Fixed` heading in changelog, fixes bugs or bad behavior
+    - `chore: {title}` - 
+    - `docs: {title}`
+    - `tests: {title}`
+- Adding a `!` before the `:` will signify this is also a breaking change
+    - This sort of change will cause a `MAJOR` version bump.
+- You can also use scopes to further detail the area your PR is changing i.e.:
+    - `feat(ladfile): add global types`
+    - `fix(ladfile_builder): fix globals not getting exported`
+    - `docs(bms): document weird vector behavior on MacOS`

--- a/.github/workflows/pr-titles.yml
+++ b/.github/workflows/pr-titles.yml
@@ -26,3 +26,7 @@ jobs:
             chore
             test
             docs
+          scopes: |
+            ladfile
+            ladfile_builder
+            bms

--- a/docs/src/Examples/introduction.md
+++ b/docs/src/Examples/introduction.md
@@ -1,5 +1,5 @@
 # Examples
 
-In the future we hope to embedd live WASM code examples into the documentation, for now the best source of examples scripts will be our regression test suite available in all supported languages in our [github repository](https://github.com/makspll/bevy_mod_scripting/tree/main/assets/tests).
+In the future we hope to embedd live WASM code examples into the documentation, for now the best source of example scripts will be our regression test suite available in all supported languages in our [github repository](https://github.com/makspll/bevy_mod_scripting/tree/main/assets/tests).
 
 For rust examples see [this folder](https://github.com/makspll/bevy_mod_scripting/tree/main/examples).

--- a/docs/src/Examples/introduction.md
+++ b/docs/src/Examples/introduction.md
@@ -1,0 +1,5 @@
+# Examples
+
+In the future we hope to embedd live WASM code examples into the documentation, for now the best source of examples scripts will be our regression test suite available in all supported languages in our [github repository](https://github.com/makspll/bevy_mod_scripting/tree/main/assets/tests).
+
+For rust examples see [this folder](https://github.com/makspll/bevy_mod_scripting/tree/main/examples).

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -12,6 +12,10 @@
 - [Script ID Mapping](./Summary/script-id-mapping.md)
 - [Script Systems](./ScriptSystems/introduction.md)
 
+# Examples
+
+- [Examples] (./Examples/introduction.md)
+
 # Scripting Reference
 
 - [Introduction](./ScriptingReference/introduction.md)

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -11,9 +11,6 @@
 - [Shared Contexts](./Summary/sharing-contexts-between-scripts.md)
 - [Script ID Mapping](./Summary/script-id-mapping.md)
 - [Script Systems](./ScriptSystems/introduction.md)
-
-# Examples
-
 - [Examples](./Examples/introduction.md)
 
 # Scripting Reference

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -14,7 +14,7 @@
 
 # Examples
 
-- [Examples] (./Examples/introduction.md)
+- [Examples](./Examples/introduction.md)
 
 # Scripting Reference
 


### PR DESCRIPTION
Just highlights that these exist without needing people to dig through the repo,

also adds a pr template with useful information