### PR TITLE
feat: add `map_get` function for cloning and returning values from a map

### DIFF
--- a/assets/tests/map_get/can_get_hashmap_value copy.rhai
+++ b/assets/tests/map_get/can_get_hashmap_value copy.rhai
@@ -1,0 +1,4 @@
+let Resource = world.get_type_by_name.call("TestResourceWithVariousFields");
+let resource = world.get_resource.call(Resource);
+
+assert(resource.string_map.map_get.call("foo") == "bar", "Expected bar, got " + resource.string_map.map_get.call("foo"));

--- a/assets/tests/map_get/can_get_hashmap_value.lua
+++ b/assets/tests/map_get/can_get_hashmap_value.lua
@@ -1,0 +1,4 @@
+local Resource = world.get_type_by_name("TestResourceWithVariousFields")
+local resource = world.get_resource(Resource)
+
+assert(resource.string_map:map_get("foo") == "bar", "Expected bar, got " .. resource.string_map:map_get("foo"))

--- a/crates/bevy_mod_scripting_core/src/reflection_extensions.rs
+++ b/crates/bevy_mod_scripting_core/src/reflection_extensions.rs
@@ -11,6 +11,12 @@ use std::{
 };
 /// Extension trait for [`PartialReflect`] providing additional functionality for working with specific types.
 pub trait PartialReflectExt {
+    /// Try to get a reference to the given key in an underyling map, if the type is a map.
+    fn try_map_get(
+        &self,
+        key: &dyn PartialReflect,
+    ) -> Result<Option<&dyn PartialReflect>, InteropError>;
+
     /// Try to remove the value at the given key, if the type supports removing with the given key.
     fn try_remove_boxed(
         &mut self,
@@ -308,6 +314,20 @@ impl<T: PartialReflect + ?Sized> PartialReflectExt for T {
                 self.get_represented_type_info().map(|ti| ti.type_id()),
                 None,
                 "clear".to_owned(),
+            )),
+        }
+    }
+
+    fn try_map_get(
+        &self,
+        key: &dyn PartialReflect,
+    ) -> Result<Option<&dyn PartialReflect>, InteropError> {
+        match self.reflect_ref() {
+            bevy::reflect::ReflectRef::Map(m) => Ok(m.get(key)),
+            _ => Err(InteropError::unsupported_operation(
+                self.get_represented_type_info().map(|ti| ti.type_id()),
+                None,
+                "map_get".to_owned(),
             )),
         }
     }


### PR DESCRIPTION
# Summary
- Adds `map_get` binding
- Same signature as `get` but is a temporary stop gap for the lack of support for reflecting into hashmaps from  `get` (due to missing functionality upstream in Bevy)
- The values are returned by value not by reference
- Adds some docs around the area

```lua
local Resource = world.get_type_by_name("TestResourceWithVariousFields")
local resource = world.get_resource(Resource)

assert(resource.string_map:map_get("foo") == "bar", "Expected bar, got " .. resource.string_map:map_get("foo"))
```

Came out from the discussion around #341 
