### PR TITLE
fix: plugin registration order affecting which globals are exported

### DIFF
--- a/crates/bevy_mod_scripting_core/src/bindings/globals/core.rs
+++ b/crates/bevy_mod_scripting_core/src/bindings/globals/core.rs
@@ -8,7 +8,8 @@ use super::AppScriptGlobalsRegistry;
 pub struct CoreScriptGlobalsPlugin;
 
 impl Plugin for CoreScriptGlobalsPlugin {
-    fn build(&self, app: &mut bevy::app::App) {
+    fn build(&self, _app: &mut bevy::app::App) {}
+    fn finish(&self, app: &mut bevy::app::App) {
         let global_registry = app
             .world_mut()
             .get_resource_or_init::<AppScriptGlobalsRegistry>()


### PR DESCRIPTION
# Summary
- The change in #340, made the plugin registration order matter
- This PR moves global extraction to `App::finalize` meaning it will happen after everything is registered with the type registry