### PR TITLE
fix: rhai reloading behavior regression from #345 [SKIP_CHANGELOG]

### DIFF
--- a/assets/tests/api_availability/api_available_on_callback.lua
+++ b/assets/tests/api_availability/api_available_on_callback.lua
@@ -1,5 +1,0 @@
-function on_test()
-    assert(world ~= nil, "World was not found")
-    assert(world.get_type_by_name("TestComponent") ~= nil, "Could not find TestComponent type")
-    Entity.from_raw(1)
-end

--- a/assets/tests/api_availability/api_available_on_callback.rhai
+++ b/assets/tests/api_availability/api_available_on_callback.rhai
@@ -1,5 +1,0 @@
-fn on_test() {
-    assert!(type_of(world) != "()", "World was not found");
-    assert!(type_of(world.get_type_by_name.call("TestComponent")) != "()", "Could not find TestComponent type");
-    Entity.from_raw.call(1);
-}

--- a/assets/tests/api_availability/api_available_on_callback_and_on_load__RETURN.lua
+++ b/assets/tests/api_availability/api_available_on_callback_and_on_load__RETURN.lua
@@ -1,0 +1,22 @@
+assert(world ~= nil, "World was not found")
+assert(world.get_type_by_name("TestComponent") ~= nil, "Could not find TestComponent type")
+local global_invocation = Entity.from_raw(1)
+
+function on_test()
+    assert(world ~= nil, "World was not found")
+    assert(world.get_type_by_name("TestComponent") ~= nil, "Could not find TestComponent type")
+    Entity.from_raw(1)
+
+    -- assert global_invocation happened
+    assert(global_invocation ~= nil, "Global invocation did not happen")
+
+    return true
+end
+
+function on_test_post_update()
+    return true
+end
+
+function on_test_last()
+    return true
+end

--- a/assets/tests/api_availability/api_available_on_callback_and_on_load__RETURN.rhai
+++ b/assets/tests/api_availability/api_available_on_callback_and_on_load__RETURN.rhai
@@ -1,0 +1,22 @@
+assert(type_of(world) != "()", "World was not found");
+assert(type_of(world.get_type_by_name.call("TestComponent")) != "()", "Could not find TestComponent type");
+let global_invocation = Entity.from_raw.call(1);
+
+fn on_test(){
+    assert(type_of(world) != "()", "World was not found");
+    assert(type_of(world.get_type_by_name.call("TestComponent")) != "()", "Could not find TestComponent type");
+    Entity.from_raw.call(1);
+
+    // assert global_invocation happened
+    assert(type_of(global_invocation) != "()", "Global invocation did not happen");
+
+    return true;
+}
+
+fn on_test_post_update(){
+    return true;
+}
+
+fn on_test_last(){
+    return true;
+}

--- a/assets/tests/api_availability/api_available_on_script_load.lua
+++ b/assets/tests/api_availability/api_available_on_script_load.lua
@@ -1,3 +1,0 @@
-assert(world ~= nil, "World was not found")
-assert(world.get_type_by_name("TestComponent") ~= nil, "Could not find TestComponent type")
-Entity.from_raw(1)

--- a/assets/tests/api_availability/api_available_on_script_load.rhai
+++ b/assets/tests/api_availability/api_available_on_script_load.rhai
@@ -1,3 +1,0 @@
-assert!(type_of(world) != "()", "World was not found");
-assert!(type_of(world.get_type_by_name.call("TestComponent")) != "()", "Could not find TestComponent type");
-let out = Entity.from_raw.call(1);

--- a/assets/tests/pop/vec.rhai
+++ b/assets/tests/pop/vec.rhai
@@ -3,4 +3,4 @@ let res = world.get_resource.call(res_type);
 
 let popped = res.vec_usize.pop.call();
 
-assert(popped == 5, "Pop did not work");
+assert(popped == 5, "Pop did not work, got " + popped);

--- a/crates/languages/bevy_mod_scripting_rhai/src/lib.rs
+++ b/crates/languages/bevy_mod_scripting_rhai/src/lib.rs
@@ -188,16 +188,18 @@ fn load_rhai_content_into_context(
     pre_handling_initializers: &[ContextPreHandlingInitializer<RhaiScriptingPlugin>],
     runtime: &mut RhaiRuntime,
 ) -> Result<(), ScriptError> {
-    let mut ast = runtime.compile(std::str::from_utf8(content)?)?;
-    ast.set_source(script.to_string());
+    context.ast = runtime.compile(std::str::from_utf8(content)?)?;
+    context.ast.set_source(script.to_string());
+
     initializers
         .iter()
         .try_for_each(|init| init(script, context))?;
     pre_handling_initializers
         .iter()
         .try_for_each(|init| init(script, Entity::from_raw(0), context))?;
-    runtime.eval_ast_with_scope(&mut context.scope, &ast)?;
-    // Unlike before, do not clear statements so that definitions persist.
+    runtime.eval_ast_with_scope(&mut context.scope, &context.ast)?;
+
+    context.ast.clear_statements();
     Ok(())
 }
 


### PR DESCRIPTION
# Summary
- Test suite wasn't catching this as it wasn't asserting that callbacks actually run in certain tests
- This is now going to be caught, tests with "__RETURN" in the name are expected to return true for all test callbacks
- This allows us to actually confidently assert certain meta logic
- Rhai now works correctly 
