### PR TITLE
chore: add more commit scopes

### DIFF
--- a/.github/workflows/pr-titles.yml
+++ b/.github/workflows/pr-titles.yml
@@ -26,6 +26,8 @@ jobs:
             chore
             test
             docs
+            refactor
+
           scopes: |
             ladfile
             ladfile_builder

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -19,11 +19,13 @@ commit_parsers = [
     { message = "^chore.*", skip = true },
     { message = "^test.*", skip = true },
     { message = "^docs.*", skip = true },
+    { message = ".*[SKIP_CHANGELOG].*", skip = true },
     { message = "^feat", group = "added" },
     { message = "^changed", group = "changed" },
     { message = "^deprecated", group = "deprecated" },
     { message = "^fix", group = "fixed" },
     { message = "^security", group = "security" },
+    { message = "^refactor", group = "refactor" },
     { message = "^.*", group = "other" },
 ]
 


### PR DESCRIPTION
# Summary
- Adds `refactor` scope
- Allows explicitly skipping changelog in commits via `[SKIP_CHANGELOG]`
