### PR TITLE
fix: unit enum variants other than `Option::None` being converted into `ScriptValue::Unit`

### DIFF
--- a/crates/bevy_mod_scripting_core/src/reflection_extensions.rs
+++ b/crates/bevy_mod_scripting_core/src/reflection_extensions.rs
@@ -138,10 +138,12 @@ impl<T: PartialReflect + ?Sized> PartialReflectExt for T {
 
     fn as_option(&self) -> Result<Option<&dyn PartialReflect>, InteropError> {
         if let bevy::reflect::ReflectRef::Enum(e) = self.reflect_ref() {
-            if let Some(field) = e.field_at(0) {
-                return Ok(Some(field));
-            } else {
-                return Ok(None);
+            if e.is_type(Some("core"), "Option") {
+                if let Some(field) = e.field_at(0) {
+                    return Ok(Some(field));
+                } else {
+                    return Ok(None);
+                }
             }
         }
 
@@ -535,7 +537,13 @@ mod test {
 
     #[test]
     fn test_as_option_none() {
+        #[derive(Reflect)]
+        enum Test {
+            Unit,
+        }
+
         assert!(None::<i32>.as_option().unwrap().is_none());
+        assert!(Test::Unit.as_option().is_err())
     }
 
     #[test]


### PR DESCRIPTION
# Summary
Currently reflecting into an enum with a unit variant value, will create a `ScriptValue::Unit` on the script side, i.e. nil for lua.
This is not great because it means you lose information about the variant.

This PR fixes the bug causing this.
