### PR TITLE
chore: revert release-plz to older config

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,5 +1,4 @@
 [workspace]
-changelog_path="./CHANGELOG.md"
 dependencies_update = false
 publish_timeout = "30m"
 git_release_enable = false
@@ -20,13 +19,11 @@ commit_parsers = [
     { message = "^chore.*", skip = true },
     { message = "^test.*", skip = true },
     { message = "^docs.*", skip = true },
-    { message = "^.*[SKIP_CHANGELOG].*", skip = true },
     { message = "^feat", group = "added" },
     { message = "^changed", group = "changed" },
     { message = "^deprecated", group = "deprecated" },
     { message = "^fix", group = "fixed" },
     { message = "^security", group = "security" },
-    { message = "^refactor", group = "refactor" },
     { message = "^.*", group = "other" },
 ]
 
@@ -39,6 +36,14 @@ git_release_enable = true
 git_tag_enable = true
 git_tag_name = "v{{ version }}"
 git_release_name = "v{{ version }}"
+
+changelog_include = [
+    "bevy_mod_scripting_lua",
+    "bevy_mod_scripting_core",
+    "bevy_mod_scripting_rhai",
+    # "bevy_mod_scripting_rune",
+    "bevy_mod_scripting_functions",
+]
 
 [[package]]
 name = "bevy_mod_scripting_lua"
@@ -66,7 +71,6 @@ name = "bevy_mod_scripting_functions"
 version_group = "main"
 
 [[package]]
-changelog_update = true
 name = "ladfile"
 git_release_enable = true
 git_release_latest = false
@@ -75,7 +79,6 @@ git_tag_name = "v{{ version }}-ladfile"
 git_release_name = "v{{ version }}-ladfile"
 
 [[package]]
-changelog_update = true
 name = "ladfile_builder"
 git_release_enable = true
 git_release_latest = false


### PR DESCRIPTION
# Summary
- enter PR summary here
- what did you change
- why did you do it this way?
- Are there alternative ways we need to keep in mind?

## Testing (Read & Delete Me)
- Did you write tests to cover new or modified behavior?
- These are not necessary, but very welcome
- I am always happy to receive any PR's, but adding tests makes it easier for me to merge them!

## Conventional PR Titles (Read & Delete me)
- This crate uses `release-plz` to manage our deploys
- A CI check will verify your PR title to make sure it uses a valid conventional prefix like:
    - `feat: {title}` - corresponds to `Added` heading in changelog, backwards compatibile changes
    - `fix: {title}` - corresponds to `Fixed` heading in changelog, fixes bugs or bad behavior
    - `chore: {title}` - does not appear in the changelog, useful for "meta" work that doesn't affect the API
    - `docs: {title}` - does not appear in the changelog, for docuemntation changes.
    - `tests: {title}` - does not appear in changelog, purely adds or changes tests.
- Adding a `!` before the `:` will signify this is also a breaking change
    - This sort of change will cause a `MAJOR` version bump.
- You can also use scopes to further detail the area your PR is changing i.e.:
    - `feat(ladfile): add global types`
    - `fix(ladfile_builder): fix globals not getting exported`
    - `docs(bms): document weird vector behavior on MacOS`
