### PR TITLE
chore: add cargo metadata to bevy_system_reflection

### DIFF
--- a/crates/bevy_system_reflection/Cargo.toml
+++ b/crates/bevy_system_reflection/Cargo.toml
@@ -2,11 +2,19 @@
 name = "bevy_system_reflection"
 version = "0.1.0"
 edition = "2024"
+authors = ["Maksymilian Mozolewski <makspl17@gmail.com>"]
+license = "MIT OR Apache-2.0"
+description = "Utilities for reflecting systems, schedules, system sets and rendering schedules"
+repository = "https://github.com/makspll/bevy_mod_scripting"
+homepage = "https://github.com/makspll/bevy_mod_scripting"
+keywords = ["bevy", "gamedev", "scripting", "lua"]
+categories = ["game-development"]
+readme = "readme.md"
 
 [dependencies]
 bevy = { workspace = true, default-features = false }
 dot-writer = "0.1.4"
-petgraph = "*"
+petgraph = "0.6"
 
 
 [dev-dependencies]

--- a/crates/bevy_system_reflection/readme.md
+++ b/crates/bevy_system_reflection/readme.md
@@ -1,0 +1,6 @@
+# Bevy System Reflection
+
+This crate is a part of the ["bevy_mod_scripting" workspace](https://github.com/makspll/bevy_mod_scripting).
+
+
+It holds some reflection logic which is not essentially core BMS logic and could theoretically be upstreamaed to Bevy.


### PR DESCRIPTION
# Summary
Adds missing cargo data for the cargo publish