### PR TITLE
feat: Add missing `luau` extension, improve extension configuration options

### DIFF
--- a/crates/bevy_mod_scripting_core/src/asset.rs
+++ b/crates/bevy_mod_scripting_core/src/asset.rs
@@ -124,11 +124,15 @@ pub struct ScriptAssetSettings {
 impl ScriptAssetSettings {
     /// Selects the language for a given asset path
     pub fn select_script_language(&self, path: &AssetPath) -> Language {
-        let extension = path.path().extension().and_then(|ext| ext.to_str()).unwrap_or_default();
+        let extension = path
+            .path()
+            .extension()
+            .and_then(|ext| ext.to_str())
+            .unwrap_or_default();
         self.extension_to_language_map
             .get(extension)
             .cloned()
-            .unwrap_or_default()    
+            .unwrap_or_default()
     }
 }
 
@@ -155,7 +159,6 @@ pub struct AssetPathToScriptIdMapper {
     /// The mapping function
     pub map: fn(&AssetPath) -> ScriptId,
 }
-
 
 /// A cache of asset id's to their script id's. Necessary since when we drop an asset we won't have the ability to get the path from the asset.
 #[derive(Default, Debug, Resource)]

--- a/crates/bevy_mod_scripting_core/src/lib.rs
+++ b/crates/bevy_mod_scripting_core/src/lib.rs
@@ -4,8 +4,8 @@
 
 use crate::event::ScriptErrorEvent;
 use asset::{
-    configure_asset_systems, configure_asset_systems_for_plugin,
-    Language, ScriptAsset, ScriptAssetLoader, ScriptAssetSettings,
+    configure_asset_systems, configure_asset_systems_for_plugin, Language, ScriptAsset,
+    ScriptAssetLoader, ScriptAssetSettings,
 };
 use bevy::prelude::*;
 use bindings::{
@@ -97,7 +97,6 @@ pub struct ScriptingPlugin<P: IntoScriptPluginParams> {
     pub context_initializers: Vec<ContextInitializer<P>>,
     /// initializers for the contexts run every time before handling events
     pub context_pre_handling_initializers: Vec<ContextPreHandlingInitializer<P>>,
-
 }
 
 impl<P: IntoScriptPluginParams> Default for ScriptingPlugin<P> {
@@ -138,7 +137,10 @@ impl<P: IntoScriptPluginParams> Plugin for ScriptingPlugin<P> {
         once_per_app_init(app);
 
         if !self.additional_supported_extensions.is_empty() {
-            app.add_supported_script_extensions(self.additional_supported_extensions, self.language.clone());
+            app.add_supported_script_extensions(
+                self.additional_supported_extensions,
+                self.language.clone(),
+            );
         }
 
         register_types(app);
@@ -202,7 +204,7 @@ pub trait ConfigureScriptPlugin {
     fn enable_context_sharing(self) -> Self;
 
     /// Set the set of extensions to be added for the plugin's language.
-    /// 
+    ///
     /// This is useful for adding extensions that are not supported by default by BMS.
     fn set_additional_supported_extensions(self, extensions: &'static [&'static str]) -> Self;
 }
@@ -238,8 +240,6 @@ impl<P: IntoScriptPluginParams + AsMut<ScriptingPlugin<P>>> ConfigureScriptPlugi
         self.as_mut().additional_supported_extensions = extensions;
         self
     }
-
-    
 }
 
 fn once_per_app_finalize(app: &mut App) {
@@ -395,13 +395,21 @@ impl ManageStaticScripts for App {
 /// Any changes to the asset settings after that will not be reflected in the asset loader.
 pub trait ConfigureScriptAssetSettings {
     /// Adds a supported extension to the asset settings
-    /// 
+    ///
     /// This is only valid to call in the plugin building phase, as the asset loader will be created in the `finalize` phase.
-    fn add_supported_script_extensions(&mut self, extensions: &[&'static str], language: Language) -> &mut Self;
+    fn add_supported_script_extensions(
+        &mut self,
+        extensions: &[&'static str],
+        language: Language,
+    ) -> &mut Self;
 }
 
 impl ConfigureScriptAssetSettings for App {
-    fn add_supported_script_extensions(&mut self, extensions: &[&'static str], language: Language) -> &mut Self {
+    fn add_supported_script_extensions(
+        &mut self,
+        extensions: &[&'static str],
+        language: Language,
+    ) -> &mut Self {
         let mut asset_settings = self
             .world_mut()
             .get_resource_or_init::<ScriptAssetSettings>();
@@ -414,7 +422,9 @@ impl ConfigureScriptAssetSettings for App {
 
         asset_settings.supported_extensions = new_arr_static;
         for extension in extensions {
-            asset_settings.extension_to_language_map.insert(*extension, language.clone());
+            asset_settings
+                .extension_to_language_map
+                .insert(*extension, language.clone());
         }
 
         self

--- a/crates/languages/bevy_mod_scripting_lua/src/lib.rs
+++ b/crates/languages/bevy_mod_scripting_lua/src/lib.rs
@@ -1,11 +1,10 @@
 //! Lua integration for the bevy_mod_scripting system.
 use bevy::{
     app::Plugin,
-    asset::AssetPath,
     ecs::{entity::Entity, world::World},
 };
 use bevy_mod_scripting_core::{
-    asset::{AssetPathToLanguageMapper, Language},
+    asset::Language,
     bindings::{
         function::namespace::Namespace, globals::AppScriptGlobalsRegistry,
         script_value::ScriptValue, ThreadWorldContainer, WorldContainer,
@@ -59,9 +58,6 @@ impl Default for LuaScriptingPlugin {
                 context_builder: ContextBuilder::<LuaScriptingPlugin> {
                     load: lua_context_load,
                     reload: lua_context_reload,
-                },
-                language_mapper: AssetPathToLanguageMapper {
-                    map: lua_language_mapper,
                 },
                 context_initializers: vec![
                     |_script_id, context| {
@@ -134,18 +130,13 @@ impl Default for LuaScriptingPlugin {
                         .map_err(ScriptError::from_mlua_error)?;
                     Ok(())
                 }],
-                additional_supported_extensions: &["lua"],
+                additional_supported_extensions: &[],
+                language: Language::Lua,
             },
         }
     }
 }
-#[profiling::function]
-fn lua_language_mapper(path: &AssetPath) -> Language {
-    match path.path().extension().and_then(|ext| ext.to_str()) {
-        Some("lua") => Language::Lua,
-        _ => Language::Unknown,
-    }
-}
+
 
 impl Plugin for LuaScriptingPlugin {
     fn build(&self, app: &mut bevy::prelude::App) {

--- a/crates/languages/bevy_mod_scripting_lua/src/lib.rs
+++ b/crates/languages/bevy_mod_scripting_lua/src/lib.rs
@@ -137,7 +137,6 @@ impl Default for LuaScriptingPlugin {
     }
 }
 
-
 impl Plugin for LuaScriptingPlugin {
     fn build(&self, app: &mut bevy::prelude::App) {
         self.scripting_plugin.build(app);

--- a/crates/languages/bevy_mod_scripting_lua/src/lib.rs
+++ b/crates/languages/bevy_mod_scripting_lua/src/lib.rs
@@ -134,7 +134,7 @@ impl Default for LuaScriptingPlugin {
                         .map_err(ScriptError::from_mlua_error)?;
                     Ok(())
                 }],
-                supported_extensions: &["lua"],
+                additional_supported_extensions: &["lua"],
             },
         }
     }

--- a/crates/languages/bevy_mod_scripting_rhai/src/lib.rs
+++ b/crates/languages/bevy_mod_scripting_rhai/src/lib.rs
@@ -2,11 +2,10 @@
 
 use bevy::{
     app::Plugin,
-    asset::AssetPath,
     ecs::{entity::Entity, world::World},
 };
 use bevy_mod_scripting_core::{
-    asset::{AssetPathToLanguageMapper, Language},
+    asset::Language,
     bindings::{
         function::namespace::Namespace, globals::AppScriptGlobalsRegistry,
         script_value::ScriptValue, ThreadWorldContainer, WorldContainer,
@@ -84,9 +83,6 @@ impl Default for RhaiScriptingPlugin {
                     load: rhai_context_load,
                     reload: rhai_context_reload,
                 },
-                language_mapper: AssetPathToLanguageMapper {
-                    map: rhai_language_mapper,
-                },
                 context_initializers: vec![
                     |_, context: &mut RhaiScriptContext| {
                         context.scope.set_or_push(
@@ -159,16 +155,11 @@ impl Default for RhaiScriptingPlugin {
                     context.scope.set_or_push("script_id", script.to_owned());
                     Ok(())
                 }],
-                additional_supported_extensions: &["rhai"],
+                // already supported by BMS core
+                additional_supported_extensions: &[],
+                language: Language::Rhai,
             },
         }
-    }
-}
-
-fn rhai_language_mapper(path: &AssetPath) -> Language {
-    match path.path().extension().and_then(|ext| ext.to_str()) {
-        Some("rhai") => Language::Rhai,
-        _ => Language::Unknown,
     }
 }
 

--- a/crates/languages/bevy_mod_scripting_rhai/src/lib.rs
+++ b/crates/languages/bevy_mod_scripting_rhai/src/lib.rs
@@ -159,7 +159,7 @@ impl Default for RhaiScriptingPlugin {
                     context.scope.set_or_push("script_id", script.to_owned());
                     Ok(())
                 }],
-                supported_extensions: &["rhai"],
+                additional_supported_extensions: &["rhai"],
             },
         }
     }

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -16,6 +16,7 @@
 # Scripting Reference
 
 - [Introduction](./ScriptingReference/introduction.md)
+- [Constructing Arbitrary Types](./ScriptingReference/constructing-arbitrary-types.md)
 - [Core Bindings](./ScriptingReference/core-api.md)
     - [World](./ScriptingReference/world.md)
     - [ReflectReference](./ScriptingReference/reflect-reference.md)

--- a/docs/src/ScriptSystems/introduction.md
+++ b/docs/src/ScriptSystems/introduction.md
@@ -4,9 +4,11 @@
 Script systems are an experimental feature
 </div>
 
-It's possible within BMS to inject new systems from scripts themselves, although the support is currently limited.
+It's possible within BMS to inject new systems from within scripts themselves.
 
-Systems introduced by scripts cannot run in parallel to other systems, but can be freely inserted between any other rust system (not script systems at the moment) and into any schedule.
+Systems introduced by scripts *can* run in parallel to other systems, and can be freely inserted between any other system, including other script systems.
+
+BMS also provides utilities for visualising schedules using dot graphs, allowing low-effort modding frameworks for game authors.
 
 
 ## Schedules
@@ -27,6 +29,7 @@ To insert a system you will need to use the `system_builder` global function lik
 
 ```lua
 local system = system_builder("my_system", script_id)
+    :exclusive()
     :after(some_other_system)
     :before(another_system)
 ```
@@ -43,9 +46,43 @@ If your event handler running the script is running in a certain schedule, that 
 
 </div>
 
-## Dynamic system
+## Parameters
 
-The system injected will be similar to an event handler, however it will only trigger the specified script, and without any entity, in the above example you'd see the following lua callback:
+The system builder allows script authors to parameterise systems, using `resource` and `query` functions.
+The order in which those functions are called, will define the order in which arguments will be provided to the specified script callback.
+
+For example:
+```lua
+system_builder("my_system")
+    :query(
+        world.query()
+            :component(ComponentA)
+            :component(ComponentB)
+            :with(ComponentC)
+            :without(ComponentD)
+    )
+    :resource(ResourceA)
+```
+
+will create a system which calls the specified callback `my_system` with 2 arguments:
+- The `ScriptQueryResult` for the first query
+    - With `components` access to ComponentA and ComponentB
+- The `ReflectReference` to `ResourceA`
+
+## Exclusive systems
+
+An exclusive system can be created using the `exclusive` function call on the system builder.
+
+This allows the system to access everything as in a normal event handler.
+
+Non-exclusive systems, will only be able to access the set of components and resources as parameterized when building the system. This is why we can run the system in parallel to other non-overlapping systems.
+
+Exclusive systems on the other hand, cannot run in parallel.
+
+
+## Callback
+
+The system injected will be similar to an event handler, however it will only trigger the specified script, and without any entity, in the first example you'd see the following lua callback:
 
 ```lua
 function my_system()

--- a/docs/src/ScriptingReference/constructing-arbitrary-types.md
+++ b/docs/src/ScriptingReference/constructing-arbitrary-types.md
@@ -1,0 +1,72 @@
+# Constructing Arbitrary Types
+
+When interfacing with bevy, we do this via reflection.
+While the generated bindings do not cover constructors for every single type that bevy or other libraries provide, reflection allows us to construct some (not all types implement `FromReflect`) types from dynamic structs.
+
+BMS exposes this ability to all script writers via the `construct` global function.
+
+
+## Structs
+
+The following struct:
+```rust,ignore
+pub struct MyStruct {
+    pub my_field: String
+}
+```
+
+can be constructed from lua like so:
+```lua
+local MyStruct = world.get_type_by_name("MyStruct")
+local concrete_my_struct = construct(MyStruct, {
+    my_field = "hello"
+})
+```
+
+## Tuple Structs
+The following tuple struct:
+```rust,ignore
+
+pub struct MyTupleStruct(pub String);
+```
+
+can be constructed like so:
+```lua
+
+local MyTupleStruct = world.get_type_by_name("MyTupleStruct")
+local concrete_my_tuple_struct = construct(MyTupleStruct, {
+    _1 = "hello"
+})
+```
+
+## Enums
+The following enum:
+```rust,ignore
+pub enum MyEnum {
+    VariantA {
+        field: String
+    },
+    VariantB
+}
+```
+
+can be constructed like so:
+```lua
+
+local MyEnum = world.get_type_by_name("MyEnum")
+local variantA = construct(MyEnum, {
+    variant = "VariantA",
+    field = "hello"
+})
+local variantB = construct(MyEnum, {
+    variant = "VariantB"
+})
+```
+
+When working with enums you can also figure out the variant at runtime using `variant_name`:
+
+```lua
+if my_enum:variant_name() == "VariantA" then
+    print(my_enum.field)
+end
+```

--- a/docs/src/ScriptingReference/introduction.md
+++ b/docs/src/ScriptingReference/introduction.md
@@ -8,5 +8,5 @@ If you are a modder, welcome! 👋, apologies for the rust-centricity of this gu
 
 Scripts will have access to a few global variables in most callbacks:
 - `world`: a static reference to the world, with all sorts of functions available
-- `entity`: the entity the script is attached to, not available on load/unload callbacks
+- `entity`: the entity the script is attached to, not available on load/unload callbacks, and in dynamic system callbacks.
 - `script_id`: the ID of the current script 

--- a/docs/src/Summary/controlling-script-bindings.md
+++ b/docs/src/Summary/controlling-script-bindings.md
@@ -59,6 +59,32 @@ hello_world2("hi from global!");
 
 Note the `new_unregistered` call instead of `new`, this is because `GlobalNamespace` is not a `Reflect` type, and the `new` call also automatically registers the type in the reflection registry.
 
+## Macros
+The above is a bit tedious, so instead you can use the `script_bindings` macro, which applies to impl blocks like so:
+
+```rust,ignore
+#[script_bindings("test_fn")]
+impl TestStruct {
+    /// My docs !!
+    /// 
+    /// Arguments:
+    /// * `_self` - the first argument
+    /// * `arg1` - the second argument
+    /// Returns:
+    /// * `return` - nothing
+    fn test_fn(_self: Ref<TestStruct>, mut arg1: usize) {}
+}
+
+
+pub fn main() {
+    let mut app = App::new();
+    register_test_fn(app.world_mut())
+}
+```
+
+Note the documentation will automatically be picked up and stored for the purposes of reflection and documentation generation, including argument/return type specific docs.
+
+
 ## Context Arguments
 
 Each script function call always receives an additional context argument: `FunctionCallContext`.

--- a/docs/src/Summary/managing-scripts.md
+++ b/docs/src/Summary/managing-scripts.md
@@ -30,7 +30,19 @@ To enable hot-loading of assets, you need to enable the necessary bevy features 
 
 Assuming that hot-reloading is enabled for your app, any changes to script assets will automatically be picked up and the scripts re-loaded.
 
-## Manually (re)loading scripts
+## File Extensions
+Normally the set of supported extensions is pre-decided by each language plugin.
+
+I.e. Lua supports ".lua" extensions and Rhai supports ".rhai" extensions.
+
+Scripts are mapped to the corresponding language plugin based on these and so it's important to use them correctly.
+
+If you would like to add more extensions you need to populate them via `app.add_supported_script_extensions`.
+
+## Advanced
+Normally not necessary, but knowing these exist could be useful for more advanced use cases.
+
+### Manually (re)loading scripts
 In order to manually re-load or load a script you can issue the `CreateOrUpdateScript` command:
 
 ```rust,ignore
@@ -39,7 +51,7 @@ CreateOrUpdateScript::<LuaScriptingPlugin>::new("my_script.lua".into(), "print(\
 
 replace `LuaScriptingPlugin` with the scripting plugin you are using.
 
-## Manually Deleting scripts
+### Manually Deleting scripts
 In order to delete a previously loaded script, you will need to issue a `DeleteScript` command like so:
 
 ```rust,ignore
@@ -48,5 +60,5 @@ DeleteScript::<LuaScriptingPlugin>::new("my_script.lua".into())
 
 replace `LuaScriptingPlugin` with the scripting plugin you are using.
 
-## Loading/Unloading timeframe
+### Loading/Unloading timeframe
 Scripts asset events are processed within the same frame they are issued. This means the moment an asset is loaded, it should be loaded and ready to use in the `Update` schedule. Similarly, the moment an asset is deleted, it should be unloaded and no longer usable in the `Update` schedule.

--- a/docs/src/Summary/running-scripts.md
+++ b/docs/src/Summary/running-scripts.md
@@ -19,6 +19,10 @@ In order to attach a script and make it runnable simply add a `ScriptComponent` 
 
 When this script is run the `entity` global will represent the entity the script is attached to. This allows you to interact with the entity in your script easilly.
 
+<div class="warning">
+Be wary of path separators, by default script ID's are derived from asset paths, which are platform dependent. Make sure to use `std::path::PathBuf` if you are targetting multiple platforms.
+</div>
+
 ## Making static scripts runnable
 
 Some scripts do not require attaching to an entity. You can run these scripts by loading them first as you would with any other script, then either adding them at app level via `add_static_script` or by issuing a `AddStaticScript` command like so:

--- a/docs/src/Summary/script-id-mapping.md
+++ b/docs/src/Summary/script-id-mapping.md
@@ -5,3 +5,7 @@ Every script is currently identified by a unique ID.
 ID's are derived from the script asset path for scripts loaded via the asset system.
 
 By default this is an identity mapping, but you can override this by modifying the `AssetPathToScriptIdMapper` inside the `ScriptAssetSettings` resource before loading the script.
+
+<div class="warning">
+Be wary of path separators, by default script ID's are derived from asset paths, which are platform dependent. Make sure to use `std::path::PathBuf` if you are targetting multiple platforms.
+</div>


### PR DESCRIPTION
# Summary
Replaces the mapper struct with a hash map, improves the `App` and `ScriptPlugin` traits so that one can choose to add additional extensions easilly in a predictable place either via:
*App*
```rust
app.add_supported_script_extensions(self.additional_supported_extensions, self.language.clone());
```
or *ScriptingPlugin*
```rust
app.add_plugins(
	LuaScriptingPlugin.set_additional_supported_extensions(&["my_ext"])
)
``` 

Also adds a bunch of docs
