### PR TITLE
feat!: shorten import paths, hide private macros

### DIFF
--- a/crates/bevy_api_gen/src/context.rs
+++ b/crates/bevy_api_gen/src/context.rs
@@ -86,7 +86,7 @@ pub(crate) const DEF_PATHS_BMS_FROM_SCRIPT: [&str; 2] = [
     "bindings::FromScript",
 ];
 pub(crate) const DEF_PATHS_BMS_INTO_SCRIPT: [&str; 2] = [
-    "bevy_mod_scripting_core::bindings:IntoScript",
+    "bevy_mod_scripting_core::bindings::IntoScript",
     "bindings::IntoScript",
 ];
 

--- a/crates/bevy_api_gen/src/context.rs
+++ b/crates/bevy_api_gen/src/context.rs
@@ -82,12 +82,12 @@ impl ReflectType<'_> {
 }
 
 pub(crate) const DEF_PATHS_BMS_FROM_SCRIPT: [&str; 2] = [
-    "bevy_mod_scripting_core::bindings::function::from::FromScript",
-    "bindings::function::from::FromScript",
+    "bevy_mod_scripting_core::bindings::FromScript",
+    "bindings::FromScript",
 ];
 pub(crate) const DEF_PATHS_BMS_INTO_SCRIPT: [&str; 2] = [
-    "bevy_mod_scripting_core::bindings::function::into::IntoScript",
-    "bindings::function::into::IntoScript",
+    "bevy_mod_scripting_core::bindings:IntoScript",
+    "bindings::IntoScript",
 ];
 
 pub(crate) const DEF_PATHS_REFLECT: [&str; 2] =

--- a/crates/bevy_api_gen/src/passes/cache_traits.rs
+++ b/crates/bevy_api_gen/src/passes/cache_traits.rs
@@ -12,6 +12,7 @@ fn dump_traits(tcx: &TyCtxt) -> String{
     let mut buffer = String::new();
     for t in tcx.all_traits() {
         buffer.push_str(&tcx.def_path_str(t));
+        buffer.push_str(", ");
     }
     buffer
 }

--- a/crates/bevy_api_gen/src/passes/cache_traits.rs
+++ b/crates/bevy_api_gen/src/passes/cache_traits.rs
@@ -1,11 +1,20 @@
 use log::trace;
 use rustc_hir::def_id::LOCAL_CRATE;
+use rustc_middle::ty::TyCtxt;
 use rustc_span::Symbol;
 
 use crate::{
     Args, BevyCtxt, DEF_PATHS_BMS_FROM_SCRIPT, DEF_PATHS_BMS_INTO_SCRIPT,
     DEF_PATHS_GET_TYPE_REGISTRATION, DEF_PATHS_REFLECT, STD_SOURCE_TRAITS,
 };
+
+fn dump_traits(tcx: &TyCtxt) -> String{
+    let mut buffer = String::new();
+    for t in tcx.all_traits() {
+        buffer.push_str(&tcx.def_path_str(t));
+    }
+    buffer
+}
 
 /// Finds and caches relevant traits, if they cannot be found throws an ICE
 pub(crate) fn cache_traits(ctxt: &mut BevyCtxt<'_>, _args: &Args) -> bool {
@@ -35,15 +44,17 @@ pub(crate) fn cache_traits(ctxt: &mut BevyCtxt<'_>, _args: &Args) -> bool {
 
     if !ctxt.cached_traits.has_all_bms_traits() {
         panic!(
-            "Could not find all bms traits in crate: {}",
-            tcx.crate_name(LOCAL_CRATE)
+            "Could not find all bms traits in crate: {}. Available traits: {}",
+            tcx.crate_name(LOCAL_CRATE),
+            dump_traits(tcx)
         )
     }
 
     if !ctxt.cached_traits.has_all_bevy_traits() {
         panic!(
-            "Could not find all reflect traits in crate: {}, did bootstrapping go wrong?",
-            tcx.crate_name(LOCAL_CRATE)
+            "Could not find all reflect traits in crate: {}, did bootstrapping go wrong?. Available traits: {}",
+            tcx.crate_name(LOCAL_CRATE),
+            dump_traits(tcx)
         )
     }
 

--- a/crates/bevy_mod_scripting_core/src/bindings/access_map.rs
+++ b/crates/bevy_mod_scripting_core/src/bindings/access_map.rs
@@ -713,7 +713,6 @@ impl DisplayCodeLocation for Option<std::panic::Location<'_>> {
     }
 }
 
-#[macro_export]
 /// A macro for claiming access to a value for reading
 macro_rules! with_access_read {
     ($access_map:expr, $id:expr, $msg:expr, $body:block) => {{
@@ -731,7 +730,7 @@ macro_rules! with_access_read {
     }};
 }
 
-#[macro_export]
+pub(crate) use with_access_read;
 /// A macro for claiming access to a value for writing
 macro_rules! with_access_write {
     ($access_map:expr, $id:expr, $msg:expr, $body:block) => {
@@ -748,8 +747,8 @@ macro_rules! with_access_write {
         }
     };
 }
+pub(crate) use with_access_write;
 
-#[macro_export]
 /// A macro for claiming global access
 macro_rules! with_global_access {
     ($access_map:expr, $msg:expr, $body:block) => {
@@ -770,6 +769,8 @@ macro_rules! with_global_access {
         }
     };
 }
+
+pub(crate) use with_global_access;
 
 #[cfg(test)]
 mod test {

--- a/crates/bevy_mod_scripting_core/src/bindings/function/arg_meta.rs
+++ b/crates/bevy_mod_scripting_core/src/bindings/function/arg_meta.rs
@@ -3,8 +3,8 @@
 use std::{ffi::OsString, path::PathBuf};
 
 use crate::{
-    bindings::{script_value::ScriptValue, ReflectReference},
-    docgen::typed_through::TypedThrough,
+    bindings::{ScriptValue, ReflectReference},
+    docgen::TypedThrough,
 };
 
 use super::{

--- a/crates/bevy_mod_scripting_core/src/bindings/function/from_ref.rs
+++ b/crates/bevy_mod_scripting_core/src/bindings/function/from_ref.rs
@@ -1,15 +1,12 @@
 //! Contains the [`FromScriptRef`] trait and its implementations.
 
 use std::{any::TypeId, ffi::OsString, path::PathBuf};
-
 use bevy::reflect::{
     DynamicEnum, DynamicList, DynamicMap, DynamicTuple, DynamicVariant, Map, PartialReflect,
 };
-
 use crate::{
-    bindings::{function::from::FromScript, WorldGuard},
+    bindings::{match_by_type, WorldGuard, FromScript},
     error::InteropError,
-    match_by_type,
     reflection_extensions::TypeInfoExtensions,
     ScriptValue,
 };

--- a/crates/bevy_mod_scripting_core/src/bindings/function/into.rs
+++ b/crates/bevy_mod_scripting_core/src/bindings/function/into.rs
@@ -1,19 +1,10 @@
 //! Implementations of the [`IntoScript`] trait for various types.
 
 use std::{borrow::Cow, collections::HashMap, ffi::OsString, path::PathBuf};
-
 use bevy::reflect::Reflect;
 
-use crate::{
-    bindings::{script_value::ScriptValue, ReflectReference, WorldGuard},
-    error::InteropError,
-    self_type_dependency_only,
-};
-
-use super::{
-    from::Val,
-    script_function::{DynamicScriptFunction, DynamicScriptFunctionMut},
-};
+use crate::{bindings::{ReflectReference, ScriptValue, WorldGuard}, error::InteropError, private::self_type_dependency_only};
+use super::{DynamicScriptFunction, DynamicScriptFunctionMut, Val};
 
 /// Converts a value into a [`ScriptValue`].
 pub trait IntoScript {

--- a/crates/bevy_mod_scripting_core/src/bindings/function/into_ref.rs
+++ b/crates/bevy_mod_scripting_core/src/bindings/function/into_ref.rs
@@ -26,8 +26,8 @@ pub trait IntoScriptRef {
     ) -> Result<ScriptValue, InteropError>;
 }
 
-#[macro_export]
 /// a utility for matching types by their [`std::any::TypeId`]
+#[macro_export]
 macro_rules! match_by_type {
     (match $on:ident {$($id:ident : $ty:ty => $conv:expr),*}) => {
         match $on {
@@ -38,6 +38,8 @@ macro_rules! match_by_type {
         }
     };
 }
+
+pub use match_by_type;
 
 #[macro_export]
 /// Downcasts a reference into a value of a given type or returns an error if the downcast fails.

--- a/crates/bevy_mod_scripting_core/src/bindings/function/mod.rs
+++ b/crates/bevy_mod_scripting_core/src/bindings/function/mod.rs
@@ -1,13 +1,15 @@
 //! Abstractions to do with dynamic script functions
 
-pub mod arg_meta;
-pub mod from;
-pub mod from_ref;
-pub mod into;
-pub mod into_ref;
-pub mod namespace;
-pub mod script_function;
-pub mod type_dependencies;
+crate::private::export_all_in_modules!{
+    arg_meta,
+    from,
+    from_ref,
+    into,
+    into_ref,
+    namespace,
+    script_function,
+    type_dependencies
+}
 
 #[cfg(test)]
 #[allow(dead_code)]

--- a/crates/bevy_mod_scripting_core/src/bindings/function/type_dependencies.rs
+++ b/crates/bevy_mod_scripting_core/src/bindings/function/type_dependencies.rs
@@ -6,7 +6,7 @@ use super::{
 };
 use crate::{
     bindings::{ReflectReference, WorldGuard},
-    error::InteropError,
+    error::InteropError, private::{no_type_dependencies, self_type_dependency_only},
 };
 use bevy::reflect::{FromReflect, GetTypeRegistration, TypeRegistry, Typed};
 use std::collections::HashMap;
@@ -18,31 +18,6 @@ pub trait GetTypeDependencies {
     fn register_type_dependencies(registry: &mut TypeRegistry);
 }
 
-#[macro_export]
-/// A macro for implementing [`GetTypeDependencies`] for types with no type dependencies.
-macro_rules! no_type_dependencies {
-    ($($path:path),*) => {
-        $(
-            impl $crate::bindings::function::type_dependencies::GetTypeDependencies for $path {
-                fn register_type_dependencies(_registry: &mut bevy::reflect::TypeRegistry) {}
-            }
-        )*
-    };
-}
-
-#[macro_export]
-/// A macro for implementing [`GetTypeDependencies`] for types that only depend on themselves.
-macro_rules! self_type_dependency_only {
-    ($($path:ty),*) => {
-        $(
-            impl $crate::bindings::function::type_dependencies::GetTypeDependencies for $path {
-                fn register_type_dependencies(registry: &mut bevy::reflect::TypeRegistry) {
-                    registry.register::<$path>();
-                }
-            }
-        )*
-    };
-}
 
 macro_rules! recursive_type_dependencies {
     ($( ($path:ty where $($bound:ident : $($bound_val:path);*),* $(,,const $const:ident : $const_ty:ty)? $(=> with $self_:ident)?) ),* )  => {

--- a/crates/bevy_mod_scripting_core/src/bindings/globals/mod.rs
+++ b/crates/bevy_mod_scripting_core/src/bindings/globals/mod.rs
@@ -10,7 +10,9 @@ use bevy::{ecs::system::Resource, utils::hashbrown::HashMap};
 use parking_lot::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 use std::{any::TypeId, borrow::Cow, sync::Arc};
 
-pub mod core;
+crate::private::export_all_in_modules!{
+    core
+}
 
 /// A send + sync wrapper around the [`ScriptGlobalsRegistry`].
 #[derive(Default, Resource, Clone)]

--- a/crates/bevy_mod_scripting_core/src/bindings/mod.rs
+++ b/crates/bevy_mod_scripting_core/src/bindings/mod.rs
@@ -1,6 +1,6 @@
 //! Abstractions to help with creating bindings between bevy and scripting languages.
 
-crate::private::export_all_in_modules!{
+crate::private::export_all_in_modules! {
     access_map,
     allocator,
     function,

--- a/crates/bevy_mod_scripting_core/src/bindings/mod.rs
+++ b/crates/bevy_mod_scripting_core/src/bindings/mod.rs
@@ -1,15 +1,15 @@
 //! Abstractions to help with creating bindings between bevy and scripting languages.
 
-pub mod access_map;
-pub mod allocator;
-pub mod function;
-pub mod globals;
-pub mod pretty_print;
-pub mod query;
-pub mod reference;
-pub mod schedule;
-pub mod script_system;
-pub mod script_value;
-pub mod world;
-
-pub use {allocator::*, query::*, reference::*, world::*};
+crate::private::export_all_in_modules!{
+    access_map,
+    allocator,
+    function,
+    globals,
+    pretty_print,
+    query,
+    reference,
+    schedule,
+    script_system,
+    script_value,
+    world,
+}

--- a/crates/bevy_mod_scripting_core/src/bindings/pretty_print.rs
+++ b/crates/bevy_mod_scripting_core/src/bindings/pretty_print.rs
@@ -2,7 +2,7 @@
 
 use crate::reflection_extensions::{FakeType, TypeIdExtensions};
 
-use super::{
+use crate::bindings::{
     access_map::ReflectAccessId, script_value::ScriptValue, ReflectAllocationId, ReflectBase,
     ReflectBaseType, ReflectReference, WorldGuard,
 };

--- a/crates/bevy_mod_scripting_core/src/bindings/query.rs
+++ b/crates/bevy_mod_scripting_core/src/bindings/query.rs
@@ -1,7 +1,7 @@
 //! Utilities for querying the world.
 
-use super::{ReflectReference, WorldAccessGuard};
-use crate::{error::InteropError, with_global_access};
+use super::{with_global_access, ReflectReference, WorldAccessGuard};
+use crate::error::InteropError;
 use bevy::{
     ecs::{
         component::ComponentId,

--- a/crates/bevy_mod_scripting_core/src/bindings/reference.rs
+++ b/crates/bevy_mod_scripting_core/src/bindings/reference.rs
@@ -6,10 +6,10 @@
 //! we need wrapper types which have owned and ref variants.
 use super::{access_map::ReflectAccessId, WorldGuard};
 use crate::{
-    bindings::ReflectAllocationId,
+    bindings::{with_access_read, with_access_write, ReflectAllocationId},
     error::InteropError,
     reflection_extensions::{PartialReflectExt, TypeIdExtensions},
-    with_access_read, with_access_write, ReflectAllocator,
+    ReflectAllocator,
 };
 use bevy::{
     ecs::{

--- a/crates/bevy_mod_scripting_core/src/bindings/world.rs
+++ b/crates/bevy_mod_scripting_core/src/bindings/world.rs
@@ -9,22 +9,15 @@ use super::{
     access_map::{
         AccessCount, AccessMapKey, AnyAccessMap, DynamicSystemMeta, ReflectAccessId,
         ReflectAccessKind, SubsetAccessMap,
-    },
-    function::{
+    }, function::{
         namespace::Namespace,
         script_function::{AppScriptFunctionRegistry, DynamicScriptFunction, FunctionCallContext},
-    },
-    pretty_print::DisplayWithWorld,
-    schedule::AppScheduleRegistry,
-    script_value::ScriptValue,
-    AppReflectAllocator, ReflectBase, ReflectBaseType, ReflectReference,
-    ScriptComponentRegistration, ScriptResourceRegistration, ScriptTypeRegistration,
+    }, pretty_print::DisplayWithWorld, schedule::AppScheduleRegistry, script_value::ScriptValue, with_global_access, AppReflectAllocator, ReflectBase, ReflectBaseType, ReflectReference, ScriptComponentRegistration, ScriptResourceRegistration, ScriptTypeRegistration
 };
 use crate::{
-    bindings::function::{from::FromScript, from_ref::FromScriptRef},
+    bindings::{function::{from::FromScript, from_ref::FromScriptRef}, with_access_read, with_access_write},
     error::InteropError,
     reflection_extensions::PartialReflectExt,
-    with_access_read, with_access_write, with_global_access,
 };
 use bevy::{
     app::AppExit,

--- a/crates/bevy_mod_scripting_core/src/docgen/mod.rs
+++ b/crates/bevy_mod_scripting_core/src/docgen/mod.rs
@@ -1,6 +1,6 @@
 //! Documentation generation for scripting languages.
 
-crate::private::export_all_in_modules!{
+crate::private::export_all_in_modules! {
     info,
     typed_through
 }

--- a/crates/bevy_mod_scripting_core/src/docgen/mod.rs
+++ b/crates/bevy_mod_scripting_core/src/docgen/mod.rs
@@ -1,4 +1,6 @@
 //! Documentation generation for scripting languages.
 
-pub mod info;
-pub mod typed_through;
+crate::private::export_all_in_modules!{
+    info,
+    typed_through
+}

--- a/crates/bevy_mod_scripting_core/src/lib.rs
+++ b/crates/bevy_mod_scripting_core/src/lib.rs
@@ -40,6 +40,8 @@ pub mod reflection_extensions;
 pub mod runtime;
 pub mod script;
 
+pub(crate) mod private;
+
 #[derive(SystemSet, Hash, Debug, Eq, PartialEq, Clone)]
 /// Labels for various BMS systems
 pub enum ScriptingSystemSet {

--- a/crates/bevy_mod_scripting_core/src/private/mod.rs
+++ b/crates/bevy_mod_scripting_core/src/private/mod.rs
@@ -35,7 +35,4 @@ macro_rules! self_type_dependency_only {
     };
 }
 
-
-pub(crate) use {export_all_in_modules, self_type_dependency_only, no_type_dependencies};
-
-
+pub(crate) use {export_all_in_modules, no_type_dependencies, self_type_dependency_only};

--- a/crates/bevy_mod_scripting_core/src/private/mod.rs
+++ b/crates/bevy_mod_scripting_core/src/private/mod.rs
@@ -1,0 +1,41 @@
+//! This module contains private functions and modules that are used internally by the crate.
+
+macro_rules! export_all_in_modules {
+    ( $( $module:ident ),* $(,)? ) => {
+        $(
+            pub mod $module;
+        )*
+        pub use {
+            $( $module::*, )*
+        };
+    };
+}
+
+/// A macro for implementing [`GetTypeDependencies`] for types with no type dependencies.
+macro_rules! no_type_dependencies {
+    ($($path:path),*) => {
+        $(
+            impl $crate::bindings::function::type_dependencies::GetTypeDependencies for $path {
+                fn register_type_dependencies(_registry: &mut bevy::reflect::TypeRegistry) {}
+            }
+        )*
+    };
+}
+
+/// A macro for implementing [`GetTypeDependencies`] for types that only depend on themselves.
+macro_rules! self_type_dependency_only {
+    ($($path:ty),*) => {
+        $(
+            impl $crate::bindings::function::type_dependencies::GetTypeDependencies for $path {
+                fn register_type_dependencies(registry: &mut bevy::reflect::TypeRegistry) {
+                    registry.register::<$path>();
+                }
+            }
+        )*
+    };
+}
+
+
+pub(crate) use {export_all_in_modules, self_type_dependency_only, no_type_dependencies};
+
+


### PR DESCRIPTION
# Summary
where we previously did `pub use my_mod` we also use `pub use my_mod::*`, this should make imports everywhere prettier and should not be a breaking change.

However removing some of the items which were previously `pub` by making them `pub (crate)` might be.


## Migration Guide
- stop using the hidden macros