### PR TITLE
feat!: re-design `GetTypeDependencies` trait & add `GetTypeDependencies` derive macro

### DIFF
--- a/crates/bevy_mod_scripting_core/src/bindings/function/arg_meta.rs
+++ b/crates/bevy_mod_scripting_core/src/bindings/function/arg_meta.rs
@@ -3,8 +3,8 @@
 use std::{ffi::OsString, path::PathBuf};
 
 use crate::{
-    bindings::{ScriptValue, ReflectReference},
-    docgen::TypedThrough,
+    bindings::{ReflectReference, ScriptValue},
+    docgen::TypedThrough, error::InteropError,
 };
 
 use super::{
@@ -76,6 +76,8 @@ impl<T1, T2> ArgMeta for Union<T1, T2> {}
 impl<T> ArgMeta for Val<T> {}
 impl<T> ArgMeta for Ref<'_, T> {}
 impl<T> ArgMeta for Mut<'_, T> {}
+
+impl<T> ArgMeta for Result<T, InteropError> {}
 
 impl<T> ArgMeta for Option<T> {
     fn default_value() -> Option<ScriptValue> {

--- a/crates/bevy_mod_scripting_core/src/bindings/function/from.rs
+++ b/crates/bevy_mod_scripting_core/src/bindings/function/from.rs
@@ -469,6 +469,17 @@ where
 pub struct Union<T1, T2>(Result<T1, T2>);
 
 impl<T1, T2> Union<T1, T2> {
+    /// Create a new union with the left value.
+    pub fn new_left(value: T1) -> Self {
+        Union(Ok(value))
+    }
+
+    /// Create a new union with the right value.
+    pub fn new_right(value: T2) -> Self {
+        Union(Err(value))
+    }
+
+
     /// Try interpret the union as the left type
     pub fn into_left(self) -> Result<T1, T2> {
         match self.0 {
@@ -482,6 +493,14 @@ impl<T1, T2> Union<T1, T2> {
         match self.0 {
             Err(r) => Ok(r),
             Ok(l) => Err(l),
+        }
+    }
+     
+    /// Map the union to another type
+    pub fn map_both<U1, U2, F: Fn(T1) -> U1, G: Fn(T2) -> U2>(self, f: F, g: G) -> Union<U1, U2> {
+        match self.0 {
+            Ok(t) => Union(Ok(f(t))),
+            Err(t) => Union(Err(g(t))),
         }
     }
 }

--- a/crates/bevy_mod_scripting_core/src/bindings/function/mod.rs
+++ b/crates/bevy_mod_scripting_core/src/bindings/function/mod.rs
@@ -17,17 +17,13 @@ mod test {
     use bevy::reflect::{FromReflect, GetTypeRegistration, Reflect, Typed};
     use bevy_mod_scripting_derive::script_bindings;
 
-    use crate::{
-        bindings::{
+    use crate::bindings::{
             function::{
                 from::{Ref, Union, Val},
                 namespace::IntoNamespace,
                 script_function::AppScriptFunctionRegistry,
-            },
-            script_value::ScriptValue,
-        },
-        docgen::typed_through::TypedThrough,
-    };
+            }, script_value::ScriptValue
+        };
 
     use super::arg_meta::{ScriptArgument, ScriptReturn, TypedScriptArgument, TypedScriptReturn};
 
@@ -137,10 +133,20 @@ mod test {
             test_is_valid_arg::<Ref<'_, T>>();
         }
 
+        fn test_union<T>()
+        where
+            T: TypedScriptArgument + TypedScriptReturn,
+            T::Underlying: FromReflect + Typed + GetTypeRegistration,
+            for<'a> T::This<'a>: Into<T>,
+        {
+            test_is_valid_arg_and_return::<Union<T, T>>();
+            test_is_valid_arg_and_return::<Union<T, Union<T, T>>>();
+        }
+
         fn test_array<T, const N: usize>()
         where
-            T: ScriptArgument + ScriptReturn,
-            T: GetTypeRegistration + FromReflect + TypedThrough + Typed,
+            T: TypedScriptArgument + TypedScriptReturn + 'static,
+            T::Underlying: FromReflect + Typed + GetTypeRegistration,
             for<'a> T::This<'a>: Into<T>,
         {
             test_is_valid_arg_and_return::<[T; N]>();
@@ -148,8 +154,8 @@ mod test {
 
         fn test_tuple<T>()
         where
-            T: ScriptArgument + ScriptReturn,
-            T: GetTypeRegistration + FromReflect + TypedThrough + Typed,
+            T: TypedScriptArgument + TypedScriptReturn + 'static,
+            T::Underlying: FromReflect + Typed + GetTypeRegistration,
             for<'a> T::This<'a>: Into<T>,
         {
             test_is_valid_arg_and_return::<()>();
@@ -160,8 +166,8 @@ mod test {
 
         fn test_option<T>()
         where
-            T: ScriptArgument + ScriptReturn,
-            T: GetTypeRegistration + FromReflect + Typed + TypedThrough,
+            T: TypedScriptArgument + TypedScriptReturn,
+            T::Underlying: FromReflect + Typed + GetTypeRegistration,
             for<'a> T::This<'a>: Into<T>,
         {
             test_is_valid_arg_and_return::<Option<T>>();
@@ -169,8 +175,8 @@ mod test {
 
         fn test_vec<T>()
         where
-            T: ScriptArgument + ScriptReturn,
-            T: GetTypeRegistration + FromReflect + Typed + TypedThrough,
+            T: TypedScriptArgument + TypedScriptReturn + 'static,
+            T::Underlying: FromReflect + Typed + GetTypeRegistration,
             for<'a> T::This<'a>: Into<T>,
         {
             test_is_valid_arg_and_return::<Vec<T>>();
@@ -178,8 +184,8 @@ mod test {
 
         fn test_hashmap<V>()
         where
-            V: ScriptArgument + ScriptReturn,
-            V: GetTypeRegistration + FromReflect + Typed + TypedThrough,
+            V: TypedScriptArgument + TypedScriptReturn + 'static,
+            V::Underlying: FromReflect + Typed + GetTypeRegistration + Eq,
             for<'a> V::This<'a>: Into<V>,
         {
             test_is_valid_arg_and_return::<std::collections::HashMap<String, V>>();

--- a/crates/bevy_mod_scripting_core/src/bindings/function/type_dependencies.rs
+++ b/crates/bevy_mod_scripting_core/src/bindings/function/type_dependencies.rs
@@ -2,73 +2,159 @@
 
 use super::{
     from::{Mut, Ref, Union, Val},
-    script_function::FunctionCallContext,
+    script_function::FunctionCallContext, DynamicScriptFunction, DynamicScriptFunctionMut,
 };
 use crate::{
-    bindings::{ReflectReference, WorldGuard},
-    error::InteropError, private::{no_type_dependencies, self_type_dependency_only},
-};
+    bindings::{ReflectReference, ScriptValue}, error::InteropError}
+;
 use bevy::reflect::{FromReflect, GetTypeRegistration, TypeRegistry, Typed};
-use std::collections::HashMap;
-use std::hash::Hash;
-
-/// Functionally identical to [`GetTypeRegistration`] but without the 'static bound
-pub trait GetTypeDependencies {
-    /// Registers the type dependencies of the implementing type with the given [`TypeRegistry`].
-    fn register_type_dependencies(registry: &mut TypeRegistry);
-}
+use bevy_mod_scripting_derive::impl_get_type_dependencies;
+use std::{collections::HashMap, ffi::OsString, hash::Hash, path::PathBuf};
 
 
-macro_rules! recursive_type_dependencies {
-    ($( ($path:ty where $($bound:ident : $($bound_val:path);*),* $(,,const $const:ident : $const_ty:ty)? $(=> with $self_:ident)?) ),* )  => {
+
+macro_rules! impl_get_type_dependencies_primitives {
+    ($($ty:ty),*) => {
         $(
-            impl<$($bound : $($bound_val +)*),* , $(const $const : $const_ty )?> GetTypeDependencies for $path {
-                fn register_type_dependencies(registry: &mut TypeRegistry) {
-                    $(
-                        registry.register::<$bound>();
-                    )*
-                    $(
-                        registry.register::<$self_>();
-                    )?
-                }
-            }
+            impl_get_type_dependencies!(
+                #[derive(GetTypeDependencies)]
+                #[get_type_dependencies(bms_core_path="crate")]
+                struct $ty where {}
+            );
         )*
     };
 }
 
+impl_get_type_dependencies_primitives!(
+    i8, i16, i32, i64, i128, u8, u16, u32, u64, u128, usize, isize, f32, f64, bool,
+    ScriptValue, DynamicScriptFunction, DynamicScriptFunctionMut, InteropError,
+    String, PathBuf, OsString, char
+);
+
+
+impl GetTypeDependencies for () {
+    type Underlying = ();
+    fn register_type_dependencies(registry: &mut TypeRegistry) {
+        registry.register::<()>();
+    }
+}
+
+impl GetTypeDependencies for &'static str {
+    type Underlying = &'static str;
+    fn register_type_dependencies(registry: &mut TypeRegistry) {
+        registry.register::<&'static str>();
+    }
+}
+
+/// Functionally identical to [`GetTypeRegistration`] but without the 'static bound
+pub trait GetTypeDependencies {
+    /// In the majority of the implementations, this will be `Self`
+    /// However some types might be `facades` for other types, in which case this will be the underlying type
+    type Underlying;
+
+    /// Registers the type dependencies of the implementing type with the given [`TypeRegistry`].
+    fn register_type_dependencies(registry: &mut TypeRegistry);
+}
+
+impl_get_type_dependencies!(
+    #[derive(GetTypeDependencies)]
+    #[get_type_dependencies(bms_core_path="crate")]
+    struct HashMap<K,V> where 
+        K::Underlying: FromReflect + Eq + Hash + Typed,
+        V::Underlying: FromReflect + Typed {}
+);
+
+impl_get_type_dependencies!(
+    #[derive(GetTypeDependencies)]
+    #[get_type_dependencies(bms_core_path="crate")]
+    struct Result<T, E> where 
+        T::Underlying: FromReflect + Typed,
+        E::Underlying: FromReflect + Typed {}
+);
+
+impl_get_type_dependencies!(
+    #[derive(GetTypeDependencies)]
+    #[get_type_dependencies(bms_core_path="crate")]
+    struct Option<T> where 
+        T::Underlying: FromReflect + Typed {}
+);
+
+impl_get_type_dependencies!(
+    #[derive(GetTypeDependencies)]
+    #[get_type_dependencies(bms_core_path="crate")]
+    struct Vec<T> where 
+        T::Underlying: FromReflect + Typed {}
+);
+
+
+impl_get_type_dependencies!(
+    #[derive(GetTypeDependencies)]
+    #[get_type_dependencies(bms_core_path="crate", underlying="Result<T1::Underlying,T2::Underlying>")]
+    struct Union<T1, T2> where 
+        T1::Underlying: FromReflect + Typed,
+        T2::Underlying: FromReflect + Typed {}
+);
+
+impl_get_type_dependencies!(
+    #[derive(GetTypeDependencies)]
+    #[get_type_dependencies(bms_core_path="crate", underlying="T", dont_recurse)]
+    struct Val<T> {}
+);
+
+impl_get_type_dependencies!(
+    #[derive(GetTypeDependencies)]
+    #[get_type_dependencies(bms_core_path="crate", underlying="T", dont_recurse)]
+    struct Ref<'a, T> {}
+);
+
+impl_get_type_dependencies!(
+    #[derive(GetTypeDependencies)]
+    #[get_type_dependencies(bms_core_path="crate", underlying="T", dont_recurse)]
+    struct Mut<'a, T> {}
+);
+
+impl_get_type_dependencies!(
+    #[derive(GetTypeDependencies)]
+    #[get_type_dependencies(bms_core_path="crate")]
+    struct ReflectReference where {}
+);
+
+impl_get_type_dependencies!(
+    #[derive(GetTypeDependencies)]
+    #[get_type_dependencies(bms_core_path="crate")]
+    struct FunctionCallContext where {}
+);
+
+
+impl <T, const N: usize> GetTypeDependencies for [T; N] where 
+    T: GetTypeDependencies,
+    T::Underlying: FromReflect + Typed,
+{
+    type Underlying = [T::Underlying; N];
+    fn register_type_dependencies(registry: &mut TypeRegistry) {
+        T::register_type_dependencies(registry);
+    }
+}
+
 macro_rules! register_tuple_dependencies {
-    ($($ty:ident),*) => {
-        impl<$($ty: GetTypeRegistration + Typed),*> GetTypeDependencies for ($($ty,)*) {
+    ($($param:ident),*) => {
+        impl <$($param),*> $crate::bindings::GetTypeDependencies for ($($param,)*) where 
+            $(
+                $param: GetTypeDependencies,
+                <$param>::Underlying: FromReflect + Typed + GetTypeRegistration,
+            )*
+        {
+            type Underlying = ($(<$param as GetTypeDependencies>::Underlying,)*);
             fn register_type_dependencies(registry: &mut TypeRegistry) {
                 $(
-                    registry.register::<$ty>();
+                    registry.register::<<$param>::Underlying>();
+                    <$param>::register_type_dependencies(registry);
                 )*
             }
         }
     };
 }
 
-no_type_dependencies!(InteropError);
-no_type_dependencies!(WorldGuard<'static>);
-self_type_dependency_only!(FunctionCallContext, ReflectReference);
-
-recursive_type_dependencies!(
-    (Val<T> where T: GetTypeRegistration),
-    (Ref<'_, T>  where T: GetTypeRegistration),
-    (Mut<'_, T>  where T: GetTypeRegistration),
-    (Result<T, InteropError>  where T: GetTypeRegistration),
-    ([T; N]  where T: GetTypeRegistration;Typed,, const N: usize => with Self),
-    (Option<T>  where T: GetTypeRegistration;FromReflect;Typed => with Self),
-    (Vec<T>  where T: GetTypeRegistration;FromReflect;Typed => with Self),
-    (HashMap<K,V> where K: GetTypeRegistration;FromReflect;Typed;Hash;Eq, V: GetTypeRegistration;FromReflect;Typed => with Self)
-);
-
-impl<T1: GetTypeDependencies, T2: GetTypeDependencies> GetTypeDependencies for Union<T1, T2> {
-    fn register_type_dependencies(registry: &mut TypeRegistry) {
-        T1::register_type_dependencies(registry);
-        T2::register_type_dependencies(registry);
-    }
-}
 
 bevy::utils::all_tuples!(register_tuple_dependencies, 1, 14, T);
 
@@ -80,8 +166,12 @@ pub trait GetFunctionTypeDependencies<Marker> {
 
 macro_rules! impl_script_function_type_dependencies{
     ($( $param:ident ),* ) => {
-        impl<F, $( $param: GetTypeDependencies ,)* O: GetTypeDependencies> GetFunctionTypeDependencies<fn($($param),*) -> O> for F
-            where F: Fn( $( $param ),* ) -> O
+        impl<F, $( $param,)* O > GetFunctionTypeDependencies<fn($($param),*) -> O> for F where 
+            O: GetTypeDependencies,
+            F: Fn( $( $param ),* ) -> O,
+            $(
+                $param: GetTypeDependencies,
+            )*
         {
             fn register_type_dependencies(registry: &mut TypeRegistry) {
                 $(

--- a/crates/bevy_mod_scripting_core/src/private/mod.rs
+++ b/crates/bevy_mod_scripting_core/src/private/mod.rs
@@ -11,28 +11,5 @@ macro_rules! export_all_in_modules {
     };
 }
 
-/// A macro for implementing [`GetTypeDependencies`] for types with no type dependencies.
-macro_rules! no_type_dependencies {
-    ($($path:path),*) => {
-        $(
-            impl $crate::bindings::function::type_dependencies::GetTypeDependencies for $path {
-                fn register_type_dependencies(_registry: &mut bevy::reflect::TypeRegistry) {}
-            }
-        )*
-    };
-}
 
-/// A macro for implementing [`GetTypeDependencies`] for types that only depend on themselves.
-macro_rules! self_type_dependency_only {
-    ($($path:ty),*) => {
-        $(
-            impl $crate::bindings::function::type_dependencies::GetTypeDependencies for $path {
-                fn register_type_dependencies(registry: &mut bevy::reflect::TypeRegistry) {
-                    registry.register::<$path>();
-                }
-            }
-        )*
-    };
-}
-
-pub(crate) use {export_all_in_modules, no_type_dependencies, self_type_dependency_only};
+pub(crate) use export_all_in_modules;

--- a/crates/bevy_mod_scripting_core/src/private/mod.rs
+++ b/crates/bevy_mod_scripting_core/src/private/mod.rs
@@ -11,5 +11,4 @@ macro_rules! export_all_in_modules {
     };
 }
 
-
 pub(crate) use export_all_in_modules;

--- a/crates/bevy_mod_scripting_derive/src/derive/get_type_dependencies.rs
+++ b/crates/bevy_mod_scripting_derive/src/derive/get_type_dependencies.rs
@@ -1,0 +1,162 @@
+use proc_macro2::TokenStream;
+use quote::{quote_spanned, ToTokens};
+use syn::{parse_quote, parse_quote_spanned, DeriveInput, WhereClause};
+
+
+
+
+/// Generate a GetTypeDependencies impl like below:
+/// For type:
+/// 
+/// ```rust,ignore
+/// #[derive(GetTypeDependencies)]
+/// #[get_type_dependencies(remote)]
+/// struct TargetType<T1: CustomBoundsT1, T2: CustomBoundsT2>{
+///     ...
+/// }
+/// ```
+/// 
+/// ```rust,ignore
+/// impl <T1,T2> GetTypeDependencies for TargetType 
+/// where
+///     T1: GetTypeDependencies,
+///     T2: GetTypeDependencies,
+///     T1::Underlying: bevy::reflect::GetTypeRegistration + CustomBoundsT1,
+///     T2::Underlying: bevy::reflect::GetTypeRegistration + CustomBoundsT2,    
+/// {
+///     type Underlying = TargetType<T1::Underlying, T2::Underlying>;
+///     pub fn get_type_dependencies(registry: &mut bevy::reflect::TypeRegistry) {
+///         T1::get_type_dependencies(registry);
+///         T2::get_type_dependencies(registry);
+/// 
+///         registry.register::<TargetType<T1::Underlying, T2::Underlying>>();
+///     }  
+/// }
+/// ```
+fn get_type_dependencies_from_input(derive_input: DeriveInput) -> TokenStream {
+    let args = match Args::parse(&derive_input.attrs) {
+        Ok(args) => args,
+        Err(error) => return error.to_compile_error(),
+    };
+
+    let bms_core = &args.bms_core_path;
+
+    
+    
+    let (impl_generics, type_generics, impl_where) = derive_input.generics.split_for_impl();
+    
+
+    let name = &derive_input.ident;
+    
+    
+    let generic_names = derive_input.generics.type_params().map(|param| &param.ident).collect::<Vec<_>>();
+
+    let type_generics_underlying = if generic_names.is_empty() {
+        Default::default()
+    } else {
+        quote_spanned! {derive_input.ident.span()=>
+            <#( #generic_names::Underlying ),*>
+        }
+    };
+
+    let underlying = if let Some(underlying) = args.underlying {
+        underlying.to_token_stream()
+    } else {
+        quote_spanned! {derive_input.ident.span()=>
+            #name #type_generics_underlying
+        }
+    };
+
+    let mut impl_where: WhereClause = impl_where.cloned().unwrap_or_else(|| parse_quote!{where});
+    let mut recursive_registrations = Vec::default();
+    for param in derive_input.generics.type_params() {
+        let param_name = &param.ident;
+        if !args.dont_recurse {
+            impl_where.predicates.push(
+                parse_quote_spanned!(param.ident.span()=> #param_name: GetTypeDependencies),
+            );
+            recursive_registrations.push(
+                quote_spanned! {param.ident.span()=>
+                    <#param_name as GetTypeDependencies>::register_type_dependencies(registry);
+                }
+            );
+        
+            impl_where.predicates.push(
+                parse_quote_spanned!(param.ident.span()=> #param_name::Underlying: bevy::reflect::GetTypeRegistration),
+            );
+        } else {
+            impl_where.predicates.push(
+                parse_quote_spanned!(param.ident.span()=> #param_name: bevy::reflect::GetTypeRegistration),
+            )
+        }
+    }
+    
+    
+    quote_spanned! {derive_input.ident.span()=>
+        #[automatically_derived]
+        #[allow(clippy::needless_lifetimes)]
+        impl #impl_generics #bms_core::bindings::GetTypeDependencies for #name #type_generics #impl_where
+        {
+            type Underlying = #underlying;
+            fn register_type_dependencies(registry: &mut bevy::reflect::TypeRegistry) {
+                #(#recursive_registrations)*
+
+                registry.register::<#underlying>();
+            }
+        }
+    }
+}
+
+pub fn get_type_dependencies(input: TokenStream) -> TokenStream {
+    let derive_input: DeriveInput = match syn::parse2(input) {
+        Ok(input) => input,
+        Err(e) => return e.into_compile_error(),
+    };
+    
+   get_type_dependencies_from_input(derive_input)
+}
+
+
+
+
+struct Args {
+    bms_core_path: syn::Path,
+    underlying: Option<syn::Type>,
+    dont_recurse: bool,
+    // bounds: Vec<syn::TypeParamBound>,
+}
+
+impl Args {
+    fn parse(attrs: &[syn::Attribute]) -> syn::Result<Self> {
+        let mut bms_core_path = parse_quote!(bevy_mod_scripting_core);
+        let mut underlying = None;
+        let mut dont_recurse = false;
+
+        for attr in attrs {
+            // find attr with name `get_type_dependencies`
+            // then parse its meta
+            if attr.path().is_ident("get_type_dependencies") {
+                attr.parse_nested_meta(|meta| {
+                    if meta.path.is_ident("bms_core_path") {
+                        let value = meta.value()?;
+                        let string: syn::LitStr = value.parse()?;
+                        bms_core_path = string.parse()?;
+                        Ok(())
+                    } else if meta.path.is_ident("underlying") {
+                        let value = meta.value()?;
+                        let string: syn::LitStr = value.parse()?;
+                        underlying = Some(string.parse()?);
+                        Ok(())
+                    } else if meta.path.is_ident("dont_recurse") {
+                        dont_recurse = true;
+                        Ok(())
+                    } else {
+                        Err(syn::Error::new_spanned(meta.path, "unknown attribute, allowed: bms_core_path, underlying"))
+                    }
+                })?;
+            }
+        }
+
+        Ok(Self { bms_core_path, underlying, dont_recurse })
+    }
+}

--- a/crates/bevy_mod_scripting_derive/src/derive/mod.rs
+++ b/crates/bevy_mod_scripting_derive/src/derive/mod.rs
@@ -1,17 +1,16 @@
+mod get_type_dependencies;
 mod into_script;
 mod script_bindings;
 mod script_globals;
 mod typed_through;
-mod get_type_dependencies;
 
 use proc_macro2::{Span, TokenStream};
 use quote::{quote_spanned, ToTokens};
 use syn::{Ident, ImplItemFn, ItemImpl};
 
 pub use self::{
-    into_script::into_script, script_bindings::script_bindings, script_globals::script_globals,
-    typed_through::typed_through,
-    get_type_dependencies::get_type_dependencies
+    get_type_dependencies::get_type_dependencies, into_script::into_script,
+    script_bindings::script_bindings, script_globals::script_globals, typed_through::typed_through,
 };
 
 pub(crate) fn impl_fn_to_namespace_builder_registration(fun: &ImplItemFn) -> TokenStream {

--- a/crates/bevy_mod_scripting_derive/src/derive/mod.rs
+++ b/crates/bevy_mod_scripting_derive/src/derive/mod.rs
@@ -2,6 +2,7 @@ mod into_script;
 mod script_bindings;
 mod script_globals;
 mod typed_through;
+mod get_type_dependencies;
 
 use proc_macro2::{Span, TokenStream};
 use quote::{quote_spanned, ToTokens};
@@ -10,6 +11,7 @@ use syn::{Ident, ImplItemFn, ItemImpl};
 pub use self::{
     into_script::into_script, script_bindings::script_bindings, script_globals::script_globals,
     typed_through::typed_through,
+    get_type_dependencies::get_type_dependencies
 };
 
 pub(crate) fn impl_fn_to_namespace_builder_registration(fun: &ImplItemFn) -> TokenStream {

--- a/crates/bevy_mod_scripting_derive/src/lib.rs
+++ b/crates/bevy_mod_scripting_derive/src/lib.rs
@@ -2,6 +2,8 @@
 
 mod derive;
 
+
+
 #[proc_macro_derive(TypedThrough)]
 /// Default implementation for the `TypedThrough` trait
 pub fn typed_through(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
@@ -48,4 +50,21 @@ pub fn script_globals(
     input: proc_macro::TokenStream,
 ) -> proc_macro::TokenStream {
     derive::script_globals(args, input)
+}
+
+/// Derive macro for generating `GetTypeDependencies` implementations.
+#[proc_macro_derive(GetTypeDependencies, attributes(get_type_dependencies))]
+pub fn get_type_dependencies(
+    input: proc_macro::TokenStream,
+) -> proc_macro::TokenStream {
+    derive::get_type_dependencies(input.into()).into()
+}
+
+/// Proc macro equivalent of `GetTypeDependencies` which does not generate a type, purely the impl.
+/// Useful for generating implementations against remote types.
+#[proc_macro]
+pub fn impl_get_type_dependencies(
+    input: proc_macro::TokenStream,
+) -> proc_macro::TokenStream {
+    derive::get_type_dependencies(input.into()).into()
 }

--- a/crates/bevy_mod_scripting_derive/src/lib.rs
+++ b/crates/bevy_mod_scripting_derive/src/lib.rs
@@ -2,8 +2,6 @@
 
 mod derive;
 
-
-
 #[proc_macro_derive(TypedThrough)]
 /// Default implementation for the `TypedThrough` trait
 pub fn typed_through(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
@@ -54,17 +52,13 @@ pub fn script_globals(
 
 /// Derive macro for generating `GetTypeDependencies` implementations.
 #[proc_macro_derive(GetTypeDependencies, attributes(get_type_dependencies))]
-pub fn get_type_dependencies(
-    input: proc_macro::TokenStream,
-) -> proc_macro::TokenStream {
+pub fn get_type_dependencies(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     derive::get_type_dependencies(input.into()).into()
 }
 
 /// Proc macro equivalent of `GetTypeDependencies` which does not generate a type, purely the impl.
 /// Useful for generating implementations against remote types.
 #[proc_macro]
-pub fn impl_get_type_dependencies(
-    input: proc_macro::TokenStream,
-) -> proc_macro::TokenStream {
+pub fn impl_get_type_dependencies(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     derive::get_type_dependencies(input.into()).into()
 }


### PR DESCRIPTION
# Summary
Currently the `GetTypeDependencies` trait struggles with deeply nested container types.

For example `HashMap<Result<T,E>,V>` would place bounds of `GetTypeRegistration` on `Result` which quickly falls apart with non-`'static` types like `Ref` and `Mut` which don't have `GetTypeRegistration` implementations.

This overhaul introduces the concept of an `Underlying` type allowing us to have two type trees, the `Real` types which we want to end up being registered in the registry, and the `Facade` types which exist purely as trait carriers:


```mermaid
graph TD;
	subgraph facade
	A1[HashMap<.Val<.T>>] --> A2["`Val<.T>`"]
	A2 --> T
	end

	subgraph underlying
    B1[HashMap<.T>] --> B2["`T`"]
    end
```

Thanks to that we can make the two assertions confidently:
- I want your REAL types in the script function signature, to be `Typed` and possible to add to the type registry
- I don't care if your FACADE types are

Also previously, `HashMap<T, Val<T>>` would not register `HashMap<T, T>` correctly at all, meaning we now get better dependency coverage!

# Migration Guide
- Any types which you implemented `GetTypeDependencies` for manually, will need to specify an underlying type, for non-generic types this will just be `Self`, for types which have recursive registrations, this will be `Self<T1::Underlying, T2::Underlying...>` etc
- You can use the derive macro to make this easier instead
