### PR TITLE
feat: add global `types` cache making `get_type_by_name` redundant

### DIFF
--- a/assets/tests/globals/type_cache_available.lua
+++ b/assets/tests/globals/type_cache_available.lua
@@ -1,0 +1,6 @@
+
+function on_test()
+    local my_type = types.TestResource;
+    assert(my_type ~= nil, "Type TestResource is not available in type cache");
+    assert(my_type:short_name() == "TestResource", "Type t.TestResource:short_name() is not correct: " .. my_type:short_name());
+end

--- a/assets/tests/globals/type_cache_available.rhai
+++ b/assets/tests/globals/type_cache_available.rhai
@@ -1,0 +1,5 @@
+fn on_test() {
+    let my_type = types.TestResource;
+    assert(type_of(my_type) != "()", "Type TestResource is not available in type cache");
+    assert(my_type.short_name.call() == "TestResource", "Type t.TestResource:short_name() is not correct: " + my_type.short_name.call());
+}

--- a/crates/bevy_mod_scripting_core/src/bindings/globals/core.rs
+++ b/crates/bevy_mod_scripting_core/src/bindings/globals/core.rs
@@ -1,6 +1,11 @@
 //! Core globals exposed by the BMS framework
 
+use std::{collections::HashMap, sync::Arc};
+
 use bevy::{app::Plugin, ecs::reflect::AppTypeRegistry};
+use bevy_mod_scripting_derive::script_globals;
+
+use crate::{bindings::{function::from::{Union, Val}, ScriptComponentRegistration, ScriptResourceRegistration, ScriptTypeRegistration, WorldGuard}, error::InteropError};
 
 use super::AppScriptGlobalsRegistry;
 
@@ -10,12 +15,16 @@ pub struct CoreScriptGlobalsPlugin;
 impl Plugin for CoreScriptGlobalsPlugin {
     fn build(&self, _app: &mut bevy::app::App) {}
     fn finish(&self, app: &mut bevy::app::App) {
-        let global_registry = app
-            .world_mut()
+        register_static_core_globals(app.world_mut());
+        register_core_globals(app.world_mut());
+    }
+}
+
+fn register_static_core_globals(world: &mut bevy::ecs::world::World) {
+    let global_registry = world
             .get_resource_or_init::<AppScriptGlobalsRegistry>()
             .clone();
-        let type_registry = app
-            .world_mut()
+        let type_registry = world
             .get_resource_or_init::<AppTypeRegistry>()
             .clone();
         let mut global_registry = global_registry.write();
@@ -34,8 +43,32 @@ impl Plugin for CoreScriptGlobalsPlugin {
                     None,
                     global_name.into(),
                     documentation.into(),
-                )
+                );
             }
         }
+}
+
+#[script_globals(
+    bms_core_path = "crate",
+    name = "core_globals",
+)]
+impl CoreGlobals {
+    /// A cache of types normally available through the `world.get_type_by_name` function.
+    /// 
+    /// You can use this to avoid having to store type references.
+    fn types(guard: WorldGuard) -> Result<HashMap<String, Union<Val<ScriptTypeRegistration>, Union<Val<ScriptComponentRegistration>, Val<ScriptResourceRegistration>>>>, InteropError> {
+        let type_registry = guard.type_registry();
+        let type_registry = type_registry.read();
+        let mut type_cache = HashMap::<String, _>::default();
+        for registration in type_registry.iter(){
+            if let Some(ident) = registration.type_info().type_path_table().ident() {
+                let registration = ScriptTypeRegistration::new(Arc::new(registration.clone()));
+                let registration = guard.clone().get_type_registration(registration)?;
+                let registration = registration.map_both(Val::from, |u| u.map_both(Val::from, Val::from));
+                type_cache.insert(ident.to_string(), registration);
+            }
+        }
+        
+        Ok(type_cache)
     }
 }

--- a/crates/bevy_mod_scripting_core/src/bindings/globals/mod.rs
+++ b/crates/bevy_mod_scripting_core/src/bindings/globals/mod.rs
@@ -100,11 +100,11 @@ impl ScriptGlobalsRegistry {
         F: Fn(WorldGuard) -> Result<T, InteropError> + 'static + Send + Sync,
     >(
         &mut self,
-        name: Cow<'static, str>,
+        name: impl Into<Cow<'static, str>>,
         maker: F,
     ) -> Option<ScriptGlobal> {
         self.globals.insert(
-            name,
+            name.into(),
             ScriptGlobal {
                 maker: Some(Self::type_erase_maker(maker)),
                 documentation: None,
@@ -122,15 +122,15 @@ impl ScriptGlobalsRegistry {
         F: Fn(WorldGuard) -> Result<T, InteropError> + 'static + Send + Sync,
     >(
         &mut self,
-        name: Cow<'static, str>,
+        name: impl Into<Cow<'static, str>>,
         maker: F,
-        documentation: Cow<'static, str>,
+        documentation: impl Into<Cow<'static, str>>,
     ) -> Option<ScriptGlobal> {
         self.globals.insert(
-            name,
+            name.into(),
             ScriptGlobal {
                 maker: Some(Self::type_erase_maker(maker)),
-                documentation: Some(documentation),
+                documentation: Some(documentation.into()),
                 type_id: TypeId::of::<T>(),
                 type_information: Some(T::through_type_info()),
             },

--- a/crates/bevy_mod_scripting_functions/src/core.rs
+++ b/crates/bevy_mod_scripting_functions/src/core.rs
@@ -30,6 +30,7 @@ use bindings::{
 };
 use error::InteropError;
 use reflection_extensions::{PartialReflectExt, TypeIdExtensions};
+
 pub fn register_bevy_bindings(app: &mut App) {
     #[cfg(feature = "bevy_bindings")]
     app.add_plugins(crate::bevy_bindings::LuaBevyScriptingPlugin);
@@ -45,39 +46,10 @@ impl World {
     fn get_type_by_name(
         ctxt: FunctionCallContext,
         type_name: String,
-    ) -> Result<Option<ReflectReference>, InteropError> {
+    ) -> Result<Option<Union<Val<ScriptTypeRegistration>, Union<Val<ScriptComponentRegistration>, Val<ScriptResourceRegistration>>>>, InteropError> {
         profiling::function_scope!("get_type_by_name");
         let world = ctxt.world()?;
-        let val = world.get_type_by_name(type_name);
-
-        Ok(match val {
-            Some(registration) => {
-                let allocator = world.allocator();
-
-                let registration = match world.get_resource_type(registration)? {
-                    Ok(res) => {
-                        let mut allocator = allocator.write();
-                        return Ok(Some(ReflectReference::new_allocated(res, &mut allocator)));
-                    }
-                    Err(registration) => registration,
-                };
-
-                let registration = match world.get_component_type(registration)? {
-                    Ok(comp) => {
-                        let mut allocator = allocator.write();
-                        return Ok(Some(ReflectReference::new_allocated(comp, &mut allocator)));
-                    }
-                    Err(registration) => registration,
-                };
-
-                let mut allocator = allocator.write();
-                Some(ReflectReference::new_allocated(
-                    registration,
-                    &mut allocator,
-                ))
-            }
-            None => None,
-        })
+        world.get_type_registration_by_name(type_name).map(|v| v.map(|v| v.map_both(Val::from, |u| u.map_both(Val::from, Val::from))))
     }
 
     /// Retrieves the schedule with the given name, Also ensures the schedule is initialized before returning it.

--- a/crates/bevy_mod_scripting_functions/src/core.rs
+++ b/crates/bevy_mod_scripting_functions/src/core.rs
@@ -46,10 +46,20 @@ impl World {
     fn get_type_by_name(
         ctxt: FunctionCallContext,
         type_name: String,
-    ) -> Result<Option<Union<Val<ScriptTypeRegistration>, Union<Val<ScriptComponentRegistration>, Val<ScriptResourceRegistration>>>>, InteropError> {
+    ) -> Result<
+        Option<
+            Union<
+                Val<ScriptTypeRegistration>,
+                Union<Val<ScriptComponentRegistration>, Val<ScriptResourceRegistration>>,
+            >,
+        >,
+        InteropError,
+    > {
         profiling::function_scope!("get_type_by_name");
         let world = ctxt.world()?;
-        world.get_type_registration_by_name(type_name).map(|v| v.map(|v| v.map_both(Val::from, |u| u.map_both(Val::from, Val::from))))
+        world
+            .get_type_registration_by_name(type_name)
+            .map(|v| v.map(|v| v.map_both(Val::from, |u| u.map_both(Val::from, Val::from))))
     }
 
     /// Retrieves the schedule with the given name, Also ensures the schedule is initialized before returning it.


### PR DESCRIPTION
# Summary
using `get_type_by_name` is slightly cumbersome. In order to not repeat yourself AND avoid polluting globals, you need to call:
```lua
local Type = world.get_type_by_name("MYType")
```
in EVERY callback, or alternatively do it once at the top of your script, but doing that goes against the advice to not run code in the body of the script outside of any functions.

this PR adds a global `types` cache, which lets you do:

```lua
types.MyType
```

or for more complex types:

```lua
types["MyGenericType<MyOtherType>"]
```

The types populated in the cache are equivalent to the types available as static globals with the addition of generic types.

The change makes use of changes in #369 to correctly type this global as `HashMap<String, ScriptComponentRegistration | ScriptResourceRegistration | ScriptTypeRegistration >` meaning once we start generating decleration files for lua we will have the correct types at hand

# Migration Guide
- Not a breaking change, but you should change instances where you call `get_type_by_name("T")` to `types["T"]` etc. this will increase performance as well as make your scripts easier to read!