### PR TITLE
feat(ladfile): improve globals in LAD format

### DIFF
--- a/crates/bevy_mod_scripting_core/src/bindings/globals/core.rs
+++ b/crates/bevy_mod_scripting_core/src/bindings/globals/core.rs
@@ -5,7 +5,7 @@ use std::{collections::HashMap, sync::Arc};
 use bevy::{app::Plugin, ecs::reflect::AppTypeRegistry};
 use bevy_mod_scripting_derive::script_globals;
 
-use crate::{bindings::{function::from::{Union, Val}, ScriptComponentRegistration, ScriptResourceRegistration, ScriptTypeRegistration, WorldGuard}, error::InteropError};
+use crate::{bindings::{function::from::{Union, Val}, ScriptComponentRegistration, ScriptResourceRegistration, ScriptTypeRegistration, WorldGuard}, docgen::into_through_type_info, error::InteropError};
 
 use super::AppScriptGlobalsRegistry;
 
@@ -38,9 +38,10 @@ fn register_static_core_globals(world: &mut bevy::ecs::world::World) {
 
             if let Some(global_name) = registration.type_info().type_path_table().ident() {
                 let documentation = "A reference to the type, allowing you to call static methods.";
+                let type_info = registration.type_info();
                 global_registry.register_static_documented_dynamic(
                     registration.type_id(),
-                    None,
+                    into_through_type_info(type_info),
                     global_name.into(),
                     documentation.into(),
                 );

--- a/crates/bevy_mod_scripting_core/src/docgen/info.rs
+++ b/crates/bevy_mod_scripting_core/src/docgen/info.rs
@@ -232,11 +232,9 @@ mod test {
         match &info.arg_info[0].type_info {
             Some(ThroughTypeInfo::UntypedWrapper {
                 through_type,
-                wrapper_type_id,
                 wrapper_kind,
             }) => {
                 assert_eq!(through_type.type_id(), TypeId::of::<i32>());
-                assert_eq!(*wrapper_type_id, TypeId::of::<Ref<'static, i32>>());
                 assert_eq!(*wrapper_kind, UntypedWrapperKind::Ref);
             }
             _ => panic!("Expected UntypedWrapper"),
@@ -245,11 +243,9 @@ mod test {
         match &info.arg_info[1].type_info {
             Some(ThroughTypeInfo::UntypedWrapper {
                 through_type,
-                wrapper_type_id,
                 wrapper_kind,
             }) => {
                 assert_eq!(through_type.type_id(), TypeId::of::<f32>());
-                assert_eq!(*wrapper_type_id, TypeId::of::<Mut<'static, f32>>());
                 assert_eq!(*wrapper_kind, UntypedWrapperKind::Mut);
             }
             _ => panic!("Expected UntypedWrapper"),

--- a/crates/bevy_mod_scripting_core/src/docgen/typed_through.rs
+++ b/crates/bevy_mod_scripting_core/src/docgen/typed_through.rs
@@ -280,14 +280,15 @@ mod test {
         }
     }
 
-    fn assert_dynamic_through_type_is_info<T: Typed + TypedThrough> () {
+    fn assert_dynamic_through_type_is_val_info<T: Typed + TypedThrough> () {
         let type_info = T::type_info();
         let through_type_info = into_through_type_info(type_info);
 
         match through_type_info {
-            ThroughTypeInfo::TypeInfo(info) => {
-                assert_eq!(info.type_id(), type_info.type_id());
-                assert_eq!(info.type_path(), type_info.type_path());
+            ThroughTypeInfo::UntypedWrapper{through_type, wrapper_kind} => {
+                assert_eq!(wrapper_kind, UntypedWrapperKind::Val);
+                assert_eq!(through_type.type_id(), type_info.type_id());
+                assert_eq!(through_type.type_path(), type_info.type_path());
             }
             _ => panic!("Expected ThroughTypeInfo::TypeInfo"),
         }
@@ -296,47 +297,47 @@ mod test {
     #[test]
     fn test_typed_through_primitives() {
         assert_type_info_is_through::<bool>();
-        assert_dynamic_through_type_is_info::<bool>();
+        assert_dynamic_through_type_is_val_info::<bool>();
         assert_type_info_is_through::<i8>();
-        assert_dynamic_through_type_is_info::<i8>();
+        assert_dynamic_through_type_is_val_info::<i8>();
         assert_type_info_is_through::<i16>();
-        assert_dynamic_through_type_is_info::<i16>();
+        assert_dynamic_through_type_is_val_info::<i16>();
         assert_type_info_is_through::<i32>();
-        assert_dynamic_through_type_is_info::<i32>();
+        assert_dynamic_through_type_is_val_info::<i32>();
         assert_type_info_is_through::<i64>();
-        assert_dynamic_through_type_is_info::<i64>();
+        assert_dynamic_through_type_is_val_info::<i64>();
         assert_type_info_is_through::<i128>();
-        assert_dynamic_through_type_is_info::<i128>();
+        assert_dynamic_through_type_is_val_info::<i128>();
         assert_type_info_is_through::<u8>();
-        assert_dynamic_through_type_is_info::<u8>();
+        assert_dynamic_through_type_is_val_info::<u8>();
         assert_type_info_is_through::<u16>();
-        assert_dynamic_through_type_is_info::<u16>();
+        assert_dynamic_through_type_is_val_info::<u16>();
         assert_type_info_is_through::<u32>();
-        assert_dynamic_through_type_is_info::<u32>();
+        assert_dynamic_through_type_is_val_info::<u32>();
         assert_type_info_is_through::<u64>();
-        assert_dynamic_through_type_is_info::<u64>();
+        assert_dynamic_through_type_is_val_info::<u64>();
         assert_type_info_is_through::<u128>();
-        assert_dynamic_through_type_is_info::<u128>();
+        assert_dynamic_through_type_is_val_info::<u128>();
         assert_type_info_is_through::<f32>();
-        assert_dynamic_through_type_is_info::<f32>();
+        assert_dynamic_through_type_is_val_info::<f32>();
         assert_type_info_is_through::<f64>();
-        assert_dynamic_through_type_is_info::<f64>();
+        assert_dynamic_through_type_is_val_info::<f64>();
         assert_type_info_is_through::<usize>();
-        assert_dynamic_through_type_is_info::<usize>();
+        assert_dynamic_through_type_is_val_info::<usize>();
         assert_type_info_is_through::<isize>();
-        assert_dynamic_through_type_is_info::<isize>();
+        assert_dynamic_through_type_is_val_info::<isize>();
         assert_type_info_is_through::<String>();
-        assert_dynamic_through_type_is_info::<String>();
+        assert_dynamic_through_type_is_val_info::<String>();
         assert_type_info_is_through::<PathBuf>();
-        assert_dynamic_through_type_is_info::<PathBuf>();
+        assert_dynamic_through_type_is_val_info::<PathBuf>();
         assert_type_info_is_through::<OsString>();
-        assert_dynamic_through_type_is_info::<OsString>();
+        assert_dynamic_through_type_is_val_info::<OsString>();
         assert_type_info_is_through::<char>();
-        assert_dynamic_through_type_is_info::<char>();
+        assert_dynamic_through_type_is_val_info::<char>();
         assert_type_info_is_through::<ReflectReference>();
-        assert_dynamic_through_type_is_info::<ReflectReference>();
+        assert_dynamic_through_type_is_val_info::<ReflectReference>();
         assert_type_info_is_through::<&'static str>();
-        assert_dynamic_through_type_is_info::<&'static str>();
+        assert_dynamic_through_type_is_val_info::<&'static str>();
     }
 
     #[test]

--- a/crates/bevy_mod_scripting_core/src/reflection_extensions.rs
+++ b/crates/bevy_mod_scripting_core/src/reflection_extensions.rs
@@ -441,6 +441,8 @@ impl<T: PartialReflect + ?Sized> PartialReflectExt for T {
 
 /// Extension trait for TypeInfos providing additional functionality for working with type information.
 pub trait TypeInfoExtensions {
+    /// Returns true if the type is a result.
+    fn is_result(&self) -> bool;
     /// Returns the inner type of the map if the type is a map, otherwise
     fn map_inner_types(&self) -> Option<(TypeId, TypeId)>;
     /// Returns the inner type of the list if the type is a list, otherwise None.
@@ -458,6 +460,10 @@ pub trait TypeInfoExtensions {
 impl TypeInfoExtensions for TypeInfo {
     fn is_option(&self) -> bool {
         self.is_type(Some("core"), "Option")
+    }
+
+    fn is_result(&self) -> bool {
+        self.is_type(Some("core"), "Result")
     }
 
     fn is_list(&self) -> bool {

--- a/crates/lad_backends/mdbook_lad_preprocessor/src/markdown.rs
+++ b/crates/lad_backends/mdbook_lad_preprocessor/src/markdown.rs
@@ -174,7 +174,8 @@ impl IntoMarkdown for Markdown {
                 }
 
                 let escaped = if *code {
-                    text.clone()
+                    // this might be a bug in the markdown renderer but we need to escape those for tables
+                    text.clone().replace("|", "\\|")
                 } else {
                     escape_markdown(text, builder.escape)
                 };
@@ -649,7 +650,7 @@ mod tests {
                     .row(vec!["Row 1 Col 1", "Row 1 Col 2"])
                     .row(markdown_vec![
                         "Row 2 Col 1",
-                        Markdown::new_paragraph("some_code").code()
+                        Markdown::new_paragraph("HashMap<String, A | B | C>").code()
                     ]);
             })
             .build();
@@ -679,7 +680,7 @@ mod tests {
             | Header 1 | Header 2 |
             | --- | --- |
             | Row 1 Col 1 | Row 1 Col 2 |
-            | Row 2 Col 1 | `some_code` |
+            | Row 2 Col 1 | `HashMap<String, A | B | C>` |
         "#;
 
         let trimmed_indentation_expected = expected

--- a/crates/lad_backends/mdbook_lad_preprocessor/src/markdown.rs
+++ b/crates/lad_backends/mdbook_lad_preprocessor/src/markdown.rs
@@ -94,9 +94,7 @@ pub enum Markdown {
         headers: Vec<String>,
         rows: Vec<Vec<String>>,
     },
-    Raw {
-        text: String,
-    },
+    Raw(String),
 }
 
 #[allow(dead_code)]
@@ -175,7 +173,7 @@ impl IntoMarkdown for Markdown {
 
                 let escaped = if *code {
                     // this might be a bug in the markdown renderer but we need to escape those for tables
-                    text.clone().replace("|", "\\|")
+                    text.clone()
                 } else {
                     escape_markdown(text, builder.escape)
                 };
@@ -279,7 +277,7 @@ impl IntoMarkdown for Markdown {
                     header_line, separator_line, rows_lines
                 ));
             }
-            Markdown::Raw { text } => {
+            Markdown::Raw(text) => {
                 builder.append(text);
             }
         }

--- a/crates/lad_backends/mdbook_lad_preprocessor/src/sections.rs
+++ b/crates/lad_backends/mdbook_lad_preprocessor/src/sections.rs
@@ -434,8 +434,8 @@ impl IntoMarkdown for SectionItem<'_> {
                 });
             }
             SectionItem::InstancesSummary { instances, ladfile } => {
-                builder.heading(2, "Globals");
-
+                builder.heading(2, "Global Values");
+                builder.text("Global values that are accessible anywhere inside scripts. You should avoid naming conflicts with these and trying to overwrite or edit them.");
                 // make a table of instances as a quick reference, make them link to instance details sub-sections
 
                 // first build a non-static instance table

--- a/crates/lad_backends/mdbook_lad_preprocessor/tests/books/example_ladfile/expected/parent/lad/globals.md
+++ b/crates/lad_backends/mdbook_lad_preprocessor/tests/books/example_ladfile/expected/parent/lad/globals.md
@@ -1,9 +1,22 @@
 # Globals
 
-## Globals
+## Global Values
+
+Global values that are accessible anywhere inside scripts\. You should avoid naming conflicts with these and trying to overwrite or edit them\.
+
+### Instances
+
+Instances containing actual accessible values\.
 
 | Instance | Type |
 | --- | --- |
-| `my_static_instance` | `StructType<usize>` |
-| `my_non_static_instance` | `Vec<UnitType>` |
-| `map` | `HashMap<String, String | String>` |
+| `my_non_static_instance` | Vec\<[UnitType](./types/unittype.md)\> |
+| `map` | HashMap\<[String](./types/string.md), [String](./types/string.md) \| [String](./types/string.md)\> |
+
+### Static Instances
+
+Static type references, existing for the purpose of typed static function calls\.
+
+| Instance | Type |
+| --- | --- |
+| `my_static_instance` | StructType\<[usize](./types/usize.md)\> |

--- a/crates/lad_backends/mdbook_lad_preprocessor/tests/books/example_ladfile/expected/parent/lad/globals.md
+++ b/crates/lad_backends/mdbook_lad_preprocessor/tests/books/example_ladfile/expected/parent/lad/globals.md
@@ -4,5 +4,6 @@
 
 | Instance | Type |
 | --- | --- |
-| `my_static_instance` | ladfile\_builder::test::StructType<usize> |
-| `my_non_static_instance` | ladfile\_builder::test::UnitType |
+| `my_static_instance` | `StructType<usize>` |
+| `my_non_static_instance` | `Vec<UnitType>` |
+| `map` | `HashMap<String, String | String>` |

--- a/crates/ladfile/test_assets/test.lad.json
+++ b/crates/ladfile/test_assets/test.lad.json
@@ -2,11 +2,37 @@
   "version": "{{version}}",
   "globals": {
     "my_static_instance": {
-      "type_id": "ladfile_builder::test::StructType<usize>",
+      "type_kind": {
+        "val": "ladfile_builder::test::StructType<usize>"
+      },
       "is_static": true
     },
     "my_non_static_instance": {
-      "type_id": "ladfile_builder::test::UnitType",
+      "type_kind": {
+        "vec": {
+          "val": "ladfile_builder::test::UnitType"
+        }
+      },
+      "is_static": false
+    },
+    "map": {
+      "type_kind": {
+        "hashMap": [
+          {
+            "primitive": "string"
+          },
+          {
+            "union": [
+              {
+                "primitive": "string"
+              },
+              {
+                "primitive": "string"
+              }
+            ]
+          }
+        ]
+      },
       "is_static": false
     }
   },

--- a/crates/ladfile_builder/src/lib.rs
+++ b/crates/ladfile_builder/src/lib.rs
@@ -625,17 +625,18 @@ impl<'t> LadFileBuilder<'t> {
 #[cfg(test)]
 mod test {
     use bevy_mod_scripting_core::{
-        bindings::{function::{
-            from::Ref,
-            namespace::{GlobalNamespace, IntoNamespace},
-        }, Union, Val},
+        bindings::{
+            function::{
+                from::Ref,
+                namespace::{GlobalNamespace, IntoNamespace},
+            },
+            Union, Val,
+        },
         docgen::info::GetFunctionInfo,
     };
     use bevy_reflect::Reflect;
 
     use super::*;
-
-
 
     /// normalize line endings etc..
     fn normalize_file(file: &mut String) {
@@ -831,7 +832,6 @@ mod test {
             "whitespace in between",
         );
     }
-
 
     /// Set to true to put output into test_assets.
     const BLESS_TEST_FILE: bool = false;

--- a/crates/ladfile_builder/src/plugin.rs
+++ b/crates/ladfile_builder/src/plugin.rs
@@ -100,7 +100,8 @@ pub fn generate_lad_file(
     // find global instances
 
     for (key, global) in global_registry.iter() {
-        builder.add_instance_dynamic(key.to_string(), global.maker.is_none(), global.type_id);
+        let type_info = global.type_information.clone();
+        builder.add_instance_dynamic(key.to_string(), global.maker.is_none(), type_info);
     }
 
     let file = builder.build();


### PR DESCRIPTION
# Summary
For now globals in the ladfile didn't really support values other than "static" instances, i.e. you could only place a `LadTypeId` in the global namespace, meaning it would have to be a pure type, and not something like `Vec<T>`.

This change allows anything in the globals that would be allowed in function arguments.

This also improves the formatting in the globals section:
- Types mentioned link to their detail sections
- Static instances are separated from non-static instances, to make it easier to read
- Descriptive text is provided

![image](https://github.com/user-attachments/assets/1e9d4a95-5500-4001-8ef2-7372ae3dc56b)
