### PR TITLE
fix: supported extensions not including default extensions [SKIP_CHANGELOG]

### DIFF
--- a/crates/bevy_mod_scripting_core/src/asset.rs
+++ b/crates/bevy_mod_scripting_core/src/asset.rs
@@ -148,7 +148,9 @@ impl Default for ScriptAssetSettings {
                 ("rhai", Language::Rhai),
                 ("rn", Language::Rune),
             ]),
-            supported_extensions: &[],
+            supported_extensions: &[
+                "lua", "luau", "rhai", "rn", 
+            ],
         }
     }
 }

--- a/crates/bevy_mod_scripting_core/src/asset.rs
+++ b/crates/bevy_mod_scripting_core/src/asset.rs
@@ -148,9 +148,7 @@ impl Default for ScriptAssetSettings {
                 ("rhai", Language::Rhai),
                 ("rn", Language::Rune),
             ]),
-            supported_extensions: &[
-                "lua", "luau", "rhai", "rn", 
-            ],
+            supported_extensions: &["lua", "luau", "rhai", "rn"],
         }
     }
 }


### PR DESCRIPTION
# Summary
fixes regression introduced in https://github.com/makspll/bevy_mod_scripting/pull/366 which caused the default extensions not to be correctly populated