### PR TITLE
chore: add query and reflection benchmarks

### DIFF
--- a/assets/benchmarks/function/call.lua
+++ b/assets/benchmarks/function/call.lua
@@ -1,0 +1,3 @@
+function bench()
+    noop()
+end

--- a/assets/benchmarks/function/call.rhai
+++ b/assets/benchmarks/function/call.rhai
@@ -1,0 +1,3 @@
+fn bench(){
+    noop.call();
+}

--- a/assets/benchmarks/function/call_4_args.lua
+++ b/assets/benchmarks/function/call_4_args.lua
@@ -1,0 +1,3 @@
+function bench()
+    noop_4_args(1,"asd",{1,2,3}, {asd = 1})
+end

--- a/assets/benchmarks/function/call_4_args.rhai
+++ b/assets/benchmarks/function/call_4_args.rhai
@@ -1,0 +1,3 @@
+fn bench(){
+    noop_4_args.call(1,"asd",[1,2,3],#{ asd: 1});
+}

--- a/assets/benchmarks/math/vec_mat_ops.lua
+++ b/assets/benchmarks/math/vec_mat_ops.lua
@@ -1,0 +1,20 @@
+
+reseed()
+
+local matrix = nil
+local vector = nil
+function pre_bench()
+    -- generate random 3x3 matrix and 3x1 vec
+    vector = Vec3.new(random(1,999), random(1,999), random(1,999))
+    matrix = Mat3.from_cols(
+        Vec3.new(random(1,999), random(1,999), random(1,999)),
+        Vec3.new(random(1,999), random(1,999), random(1,999)),
+        Vec3.new(random(1,999), random(1,999), random(1,999))
+    )
+end
+
+function bench()
+    local mul = matrix * vector
+    local add = matrix + vector
+    local div = vector / matrix
+end

--- a/assets/benchmarks/math/vec_mat_ops.rhai
+++ b/assets/benchmarks/math/vec_mat_ops.rhai
@@ -1,0 +1,19 @@
+
+reseed.call();
+
+let matrix = ();
+let vector = ();
+fn pre_bench(){
+    vector = Vec3.new_.call(random.call(1,999), random.call(1,999), random.call(1,999));
+    matrix = Mat3.from_cols.call(
+        Vec3.new_.call(random.call(1,999), random.call(1,999), random.call(1,999)),
+        Vec3.new_.call(random.call(1,999), random.call(1,999), random.call(1,999)),
+        Vec3.new_.call(random.call(1,999), random.call(1,999), random.call(1,999))
+    );
+}
+
+fn bench() {
+    let mul = matrix * vector;
+    let add = matrix + vector;
+    let div = vector / matrix;
+}

--- a/assets/benchmarks/query/1000_entities.lua
+++ b/assets/benchmarks/query/1000_entities.lua
@@ -1,0 +1,35 @@
+local entity_a = world.spawn()
+local entity_b = world.spawn()
+local entity_c = world.spawn()
+
+local components = {
+    types.CompWithDefaultAndComponentData,
+    types.CompWithFromWorldAndComponentData,
+    types.SimpleTupleStruct,
+    types.SimpleEnum,
+}
+
+reseed()
+
+for i = 1, 1000 do
+    local entity = world.spawn()
+    -- spawn 1000 entities with random components
+    local left_to_pick = {1,2,3,4}
+    for j = 1, 3 do
+        local index = random_int(1, #left_to_pick)
+        local component = components[left_to_pick[index]]
+        table.remove(left_to_pick, index)
+        world.add_default_component(entity, component)
+    end
+end
+
+function bench() 
+    for i,result in pairs(world.query()
+        :component(types.CompWithFromWorldAndComponentData)
+        :component(types.SimpleTupleStruct)
+        :with(types.SimpleEnum)
+        :without(types.CompWithDefaultAndComponentData)
+        :build()) do 
+    
+    end 
+end

--- a/assets/benchmarks/query/1000_entities.rhai
+++ b/assets/benchmarks/query/1000_entities.rhai
@@ -1,0 +1,34 @@
+let entity_a = world.spawn_.call();
+let entity_b = world.spawn_.call();
+let entity_c = world.spawn_.call();
+
+let components = [
+    types.CompWithDefaultAndComponentData,
+    types.CompWithFromWorldAndComponentData,
+    types.SimpleTupleStruct,
+    types.SimpleEnum,
+];
+
+reseed.call();
+
+for i in 1..=1000 {
+    let entity = world.spawn_.call();
+    // spawn 1000 entities with random components
+    let left_to_pick = [0, 1, 2, 3];
+    for j in 1..=3 {
+        let index = random_int.call(1, left_to_pick.len()) - 1;
+        let component = components[left_to_pick[index]];
+        left_to_pick.remove(index);
+        world.add_default_component.call(entity, component);
+    };
+};
+
+fn bench() {
+    for (result, i) in world.query.call()
+        .component.call(types.CompWithFromWorldAndComponentData)
+        .component.call(types.SimpleTupleStruct)
+        .with_.call(types.SimpleEnum)
+        .without.call(types.CompWithDefaultAndComponentData)
+        .build.call() {
+    };
+}

--- a/assets/benchmarks/query/100_entities.lua
+++ b/assets/benchmarks/query/100_entities.lua
@@ -1,0 +1,34 @@
+local entity_a = world.spawn()
+local entity_b = world.spawn()
+local entity_c = world.spawn()
+
+local components = {
+    types.CompWithDefaultAndComponentData,
+    types.CompWithFromWorldAndComponentData,
+    types.SimpleTupleStruct,
+    types.SimpleEnum,
+}
+
+reseed()
+
+for i = 1, 100 do
+    local entity = world.spawn()
+    local left_to_pick = {1,2,3,4}
+    for j = 1, 3 do
+        local index = random_int(1, #left_to_pick)
+        local component = components[left_to_pick[index]]
+        table.remove(left_to_pick, index)
+        world.add_default_component(entity, component)
+    end
+end
+
+function bench() 
+    for i,result in pairs(world.query()
+        :component(types.CompWithFromWorldAndComponentData)
+        :component(types.SimpleTupleStruct)
+        :with(types.SimpleEnum)
+        :without(types.CompWithDefaultAndComponentData)
+        :build()) do 
+    
+    end 
+end

--- a/assets/benchmarks/query/100_entities.rhai
+++ b/assets/benchmarks/query/100_entities.rhai
@@ -1,0 +1,33 @@
+let entity_a = world.spawn_.call();
+let entity_b = world.spawn_.call();
+let entity_c = world.spawn_.call();
+
+let components = [
+    types.CompWithDefaultAndComponentData,
+    types.CompWithFromWorldAndComponentData,
+    types.SimpleTupleStruct,
+    types.SimpleEnum,
+];
+
+reseed.call();
+
+for i in 1..=100 {
+    let entity = world.spawn_.call();
+    let left_to_pick = [0, 1, 2, 3];
+    for j in 1..=3 {
+        let index = random_int.call(1, left_to_pick.len()) - 1;
+        let component = components[left_to_pick[index]];
+        left_to_pick.remove(index);
+        world.add_default_component.call(entity, component);
+    };
+};
+
+fn bench() {
+    for (result, i) in world.query.call()
+        .component.call(types.CompWithFromWorldAndComponentData)
+        .component.call(types.SimpleTupleStruct)
+        .with_.call(types.SimpleEnum)
+        .without.call(types.CompWithDefaultAndComponentData)
+        .build.call() {
+    };
+}

--- a/assets/benchmarks/query/10_entities.lua
+++ b/assets/benchmarks/query/10_entities.lua
@@ -1,0 +1,34 @@
+local entity_a = world.spawn()
+local entity_b = world.spawn()
+local entity_c = world.spawn()
+
+local components = {
+    types.CompWithDefaultAndComponentData,
+    types.CompWithFromWorldAndComponentData,
+    types.SimpleTupleStruct,
+    types.SimpleEnum,
+}
+
+reseed()
+
+for i = 1, 10 do
+    local entity = world.spawn()
+    local left_to_pick = {1,2,3,4}
+    for j = 1, 3 do
+        local index = random_int(1, #left_to_pick)
+        local component = components[left_to_pick[index]]
+        table.remove(left_to_pick, index)
+        world.add_default_component(entity, component)
+    end
+end
+
+function bench() 
+    for i,result in pairs(world.query()
+        :component(types.CompWithFromWorldAndComponentData)
+        :component(types.SimpleTupleStruct)
+        :with(types.SimpleEnum)
+        :without(types.CompWithDefaultAndComponentData)
+        :build()) do 
+    
+    end 
+end

--- a/assets/benchmarks/query/10_entities.rhai
+++ b/assets/benchmarks/query/10_entities.rhai
@@ -1,0 +1,33 @@
+let entity_a = world.spawn_.call();
+let entity_b = world.spawn_.call();
+let entity_c = world.spawn_.call();
+
+let components = [
+    types.CompWithDefaultAndComponentData,
+    types.CompWithFromWorldAndComponentData,
+    types.SimpleTupleStruct,
+    types.SimpleEnum,
+];
+
+reseed.call();
+
+for i in 1..=10 {
+    let entity = world.spawn_.call();
+    let left_to_pick = [0, 1, 2, 3];
+    for j in 1..=3 {
+        let index = random_int.call(1, left_to_pick.len()) - 1;
+        let component = components[left_to_pick[index]];
+        left_to_pick.remove(index);
+        world.add_default_component.call(entity, component);
+    };
+};
+
+fn bench() {
+    for (result, i) in world.query.call()
+        .component.call(types.CompWithFromWorldAndComponentData)
+        .component.call(types.SimpleTupleStruct)
+        .with_.call(types.SimpleEnum)
+        .without.call(types.CompWithDefaultAndComponentData)
+        .build.call() {
+    };
+}

--- a/assets/benchmarks/reflection/10.lua
+++ b/assets/benchmarks/reflection/10.lua
@@ -24,6 +24,8 @@ local current_reference = nil
 local steps = 100
 local step_keys = {}
 function pre_bench()
+    step_keys = {}
+    current_reference = nil
     -- Choose keys for every step.
     for i = 1, steps do
         local key = keys[random_int(1, #keys)]

--- a/assets/benchmarks/reflection/10.lua
+++ b/assets/benchmarks/reflection/10.lua
@@ -1,0 +1,50 @@
+-- create a dynamic component with n depth of fields
+local Component = world.register_new_component("DeepComponent");
+local new_entity = world.spawn();
+
+reseed()
+
+local keys = {
+    "_0",
+    "my_key",
+    "longish_key"
+}
+
+-- Recursively build a single nested table using the pre-selected step_keys.
+local function make_path(step_keys, index)
+    if index > #step_keys then
+        return {}
+    end
+    local key = step_keys[index]
+    return { [key] = make_path(step_keys, index + 1) }
+end
+
+
+local current_reference = nil
+local steps = 10
+local step_keys = {}
+function pre_bench()
+    -- Choose keys for every step.
+    for i = 1, steps do
+        local key = keys[random_int(1, #keys)]
+        step_keys[i] = key
+    end
+
+    -- Build the nested table.
+    local instance = make_path(step_keys, 1)
+    world.remove_component(new_entity, Component)
+    world.insert_component(new_entity, Component, construct(types.DynamicComponent, {
+        data = instance
+    }))
+    current_reference = world.get_component(new_entity, Component)
+end
+
+function bench()
+    -- reference into random key into current_reference steps times
+    local reference = current_reference.data
+    local current_step = 1
+    while current_step <= steps do
+        reference = reference[step_keys[current_step]]
+        current_step = current_step + 1
+    end
+end

--- a/assets/benchmarks/reflection/10.lua
+++ b/assets/benchmarks/reflection/10.lua
@@ -21,7 +21,7 @@ end
 
 
 local current_reference = nil
-local steps = 100
+local steps = 10
 local step_keys = {}
 function pre_bench()
     step_keys = {}

--- a/assets/benchmarks/reflection/10.rhai
+++ b/assets/benchmarks/reflection/10.rhai
@@ -16,7 +16,7 @@ fn make_path(step_keys, index) {
     let key = step_keys[index];
     let nested = make_path(step_keys, index + 1);
     let obj = #{};
-    obj.insert(key, nested);
+    obj[key] = nested;
     return obj;
 };
 

--- a/assets/benchmarks/reflection/10.rhai
+++ b/assets/benchmarks/reflection/10.rhai
@@ -1,4 +1,4 @@
-let Component = world.register_new_component_.call("DeepComponent");
+let Component = world.register_new_component.call("DeepComponent");
 let new_entity = world.spawn_.call();
 
 reseed.call();

--- a/assets/benchmarks/reflection/10.rhai
+++ b/assets/benchmarks/reflection/10.rhai
@@ -1,0 +1,49 @@
+let Component = world.register_new_component_.call("DeepComponent");
+let new_entity = world.spawn_.call();
+
+reseed.call();
+
+let keys = [
+    "_0",
+    "my_key",
+    "longish_key"
+];
+
+fn make_path(step_keys, index) {
+    if index >= step_keys.len() {
+        return #{};
+    };
+    let key = step_keys[index];
+    let nested = make_path(step_keys, index + 1);
+    let obj = #{};
+    obj.insert(key, nested);
+    return obj;
+};
+
+let current_reference = ();
+let steps = 10;
+let step_keys = [];
+
+fn pre_bench() {
+    // Choose keys for every step.
+    for i in 0 .. steps {
+        let key = keys[random_int.call(0, keys.len() - 1)];
+        step_keys.push(key);
+    };
+
+    // Build the nested table.
+    let instance = make_path(step_keys, 0);
+    world.remove_component.call(new_entity, Component);
+    world.insert_component.call(new_entity, Component, construct.call(types.DynamicComponent, #{ "data": instance }));
+    current_reference = world.get_component.call(new_entity, Component);
+};
+
+fn bench() {
+    // reference into random key into current_reference steps times
+    let reference = current_reference.data;
+    let current_step = 0;
+    while current_step < steps {
+        reference = reference[step_keys[current_step]];
+        current_step += 1;
+    };
+};

--- a/assets/benchmarks/reflection/10.rhai
+++ b/assets/benchmarks/reflection/10.rhai
@@ -16,7 +16,7 @@ fn make_path(step_keys, index) {
     let key = step_keys[index];
     let nested = make_path(step_keys, index + 1);
     let obj = #{};
-    obj[key] = nested;
+    obj.set(key,nested);
     return obj;
 };
 

--- a/assets/benchmarks/reflection/10.rhai
+++ b/assets/benchmarks/reflection/10.rhai
@@ -25,6 +25,9 @@ let steps = 10;
 let step_keys = [];
 
 fn pre_bench() {
+    step_keys = [];
+    current_reference = ();
+
     // Choose keys for every step.
     for i in 0 .. steps {
         let key = keys[random_int.call(0, keys.len() - 1)];

--- a/assets/benchmarks/reflection/100.lua
+++ b/assets/benchmarks/reflection/100.lua
@@ -24,6 +24,9 @@ local current_reference = nil
 local steps = 10
 local step_keys = {}
 function pre_bench()
+    step_keys = {}
+    current_reference = nil
+    
     -- Choose keys for every step.
     for i = 1, steps do
         local key = keys[random_int(1, #keys)]

--- a/assets/benchmarks/reflection/100.lua
+++ b/assets/benchmarks/reflection/100.lua
@@ -21,7 +21,7 @@ end
 
 
 local current_reference = nil
-local steps = 10
+local steps = 100
 local step_keys = {}
 function pre_bench()
     step_keys = {}

--- a/assets/benchmarks/reflection/100.lua
+++ b/assets/benchmarks/reflection/100.lua
@@ -21,7 +21,7 @@ end
 
 
 local current_reference = nil
-local steps = 100
+local steps = 10
 local step_keys = {}
 function pre_bench()
     -- Choose keys for every step.

--- a/assets/benchmarks/reflection/100.rhai
+++ b/assets/benchmarks/reflection/100.rhai
@@ -16,7 +16,7 @@ fn make_path(step_keys, index) {
     let key = step_keys[index];
     let nested = make_path(step_keys, index + 1);
     let obj = #{};
-    obj.insert(key, nested);
+    obj[key] = nested;
     return obj;
 };
 

--- a/assets/benchmarks/reflection/100.rhai
+++ b/assets/benchmarks/reflection/100.rhai
@@ -16,7 +16,7 @@ fn make_path(step_keys, index) {
     let key = step_keys[index];
     let nested = make_path(step_keys, index + 1);
     let obj = #{};
-    obj[key] = nested;
+    obj.set(key,nested);
     return obj;
 };
 

--- a/assets/benchmarks/reflection/100.rhai
+++ b/assets/benchmarks/reflection/100.rhai
@@ -25,6 +25,9 @@ let steps = 100;
 let step_keys = [];
 
 fn pre_bench() {
+    step_keys = [];
+    current_reference = ();
+
     // Choose keys for every step.
     for i in 0 .. steps {
         let key = keys[random_int.call(0, keys.len() - 1)];

--- a/assets/benchmarks/reflection/100.rhai
+++ b/assets/benchmarks/reflection/100.rhai
@@ -1,0 +1,49 @@
+let Component = world.register_new_component.call("DeepComponent");
+let new_entity = world.spawn_.call();
+
+reseed.call();
+
+let keys = [
+    "_0",
+    "my_key",
+    "longish_key"
+];
+
+fn make_path(step_keys, index) {
+    if index >= step_keys.len() {
+        return #{};
+    };
+    let key = step_keys[index];
+    let nested = make_path(step_keys, index + 1);
+    let obj = #{};
+    obj.insert(key, nested);
+    return obj;
+};
+
+let current_reference = ();
+let steps = 100;
+let step_keys = [];
+
+fn pre_bench() {
+    // Choose keys for every step.
+    for i in 0 .. steps {
+        let key = keys[random_int.call(0, keys.len() - 1)];
+        step_keys.push(key);
+    };
+
+    // Build the nested table.
+    let instance = make_path(step_keys, 0);
+    world.remove_component.call(new_entity, Component);
+    world.insert_component.call(new_entity, Component, construct.call(types.DynamicComponent, #{ "data": instance }));
+    current_reference = world.get_component.call(new_entity, Component);
+};
+
+fn bench() {
+    // reference into random key into current_reference steps times
+    let reference = current_reference.data;
+    let current_step = 0;
+    while current_step < steps {
+        reference = reference[step_keys[current_step]];
+        current_step += 1;
+    };
+};

--- a/crates/testing_crates/script_integration_test_harness/Cargo.toml
+++ b/crates/testing_crates/script_integration_test_harness/Cargo.toml
@@ -22,3 +22,5 @@ pretty_assertions = "1.*"
 bevy_mod_scripting_lua = { path = "../../languages/bevy_mod_scripting_lua", optional = true }
 bevy_mod_scripting_rhai = { path = "../../languages/bevy_mod_scripting_rhai", optional = true }
 criterion = "0.5"
+rand = "0.9"
+rand_chacha = "0.9"

--- a/crates/testing_crates/script_integration_test_harness/src/lib.rs
+++ b/crates/testing_crates/script_integration_test_harness/src/lib.rs
@@ -142,7 +142,7 @@ pub fn make_test_rhai_plugin() -> bevy_mod_scripting_rhai::RhaiScriptingPlugin {
 
     RhaiScriptingPlugin::default().add_runtime_initializer(|runtime| {
         let mut runtime = runtime.write();
-
+        runtime.set_max_call_levels(1000);
         runtime.register_fn("assert", |a: Dynamic, b: &str| {
             if !a.is::<bool>() {
                 panic!("Expected a boolean value, but got {:?}", a);

--- a/crates/testing_crates/script_integration_test_harness/src/lib.rs
+++ b/crates/testing_crates/script_integration_test_harness/src/lib.rs
@@ -355,7 +355,11 @@ pub fn run_lua_benchmark<M: criterion::measurement::Measurement>(
         criterion,
         |ctxt, _runtime, label, criterion| {
             let bencher: Function = ctxt.globals().get("bench").map_err(|e| e.to_string())?;
+            let pre_bencher: Option<Function> = ctxt.globals().get("pre_bench").ok();
             criterion.bench_function(label, |c| {
+                if let Some(pre_bencher) = &pre_bencher {
+                    pre_bencher.call::<()>(()).unwrap();
+                }
                 c.iter(|| {
                     bencher.call::<()>(()).unwrap();
                 })
@@ -382,7 +386,14 @@ pub fn run_rhai_benchmark<M: criterion::measurement::Measurement>(
         |ctxt, runtime, label, criterion| {
             let runtime = runtime.read();
             const ARGS: [usize; 0] = [];
+            let has_pre_bench = ctxt.ast.iter_functions().any(|f| f.name == "pre_bench");
             criterion.bench_function(label, |c| {
+                // call "pre_bench" if any
+                if has_pre_bench {
+                    let _ = runtime
+                        .call_fn::<Dynamic>(&mut ctxt.scope, &ctxt.ast, "pre_bench", ARGS)
+                        .unwrap();
+                }
                 c.iter(|| {
                     let _ = runtime
                         .call_fn::<Dynamic>(&mut ctxt.scope, &ctxt.ast, "bench", ARGS)

--- a/crates/testing_crates/script_integration_test_harness/src/test_functions.rs
+++ b/crates/testing_crates/script_integration_test_harness/src/test_functions.rs
@@ -18,7 +18,7 @@ use bevy_mod_scripting_core::{
         },
         pretty_print::DisplayWithWorld,
         ReflectReference, ScriptComponentRegistration, ScriptResourceRegistration,
-        ScriptTypeRegistration,
+        ScriptTypeRegistration, ScriptValue,
     },
     error::InteropError,
 };
@@ -137,6 +137,11 @@ pub fn register_test_functions(world: &mut App) {
             *rng = ChaCha12Rng::from_seed(seed);
         })
         .register("make_hashmap", |map: HashMap<String, usize>| map)
+        .register("noop", || {})
+        .register(
+            "noop_4_args",
+            |_a: ScriptValue, _b: ScriptValue, _c: ScriptValue, _d: ScriptValue| {},
+        )
         .register(
             "assert_str_eq",
             |s1: String, s2: String, reason: Option<String>| {

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -349,11 +349,11 @@ impl App {
             Xtasks::Install { binary } => {
                 cmd.arg("install").arg(binary.as_ref());
             }
-            Xtasks::Bench { publish: execute } => {
+            Xtasks::Bench { publish } => {
                 cmd.arg("bench");
 
-                if execute {
-                    cmd.arg("--execute");
+                if publish {
+                    cmd.arg("--publish");
                 }
             }
         }


### PR DESCRIPTION
# Summary
- Adds more interesting benchmarks around querying and reflection, revealing slower parts of BMS and/or Bevy
- Re-create all plots based on benchmarks present every push to main