### PR TITLE
fix: fix global type cache not containing generic types

### DIFF
--- a/assets/tests/globals/type_cache_available.lua
+++ b/assets/tests/globals/type_cache_available.lua
@@ -3,4 +3,8 @@ function on_test()
     local my_type = types.TestResource;
     assert(my_type ~= nil, "Type TestResource is not available in type cache");
     assert(my_type:short_name() == "TestResource", "Type t.TestResource:short_name() is not correct: " .. my_type:short_name());
+
+    local my_generic_type = types["GenericComponent<String>"];
+    assert(my_generic_type ~= nil, "Type GenericComponent<String> is not available in type cache");
+    assert(my_generic_type:short_name() == "GenericComponent<String>", "Type t.GenericComponent<String>:short_name() is not correct: " .. my_generic_type:short_name());
 end

--- a/assets/tests/globals/type_cache_available.rhai
+++ b/assets/tests/globals/type_cache_available.rhai
@@ -2,4 +2,8 @@ fn on_test() {
     let my_type = types.TestResource;
     assert(type_of(my_type) != "()", "Type TestResource is not available in type cache");
     assert(my_type.short_name.call() == "TestResource", "Type t.TestResource:short_name() is not correct: " + my_type.short_name.call());
+
+    let my_type = types["GenericComponent<String>"];
+    assert(type_of(my_type) != "()", "Type GenericComponent<String> is not available in type cache");
+    assert(my_type.short_name.call() == "GenericComponent<String>", "Type t.GenericComponent<String>:short_name() is not correct: " + my_type.short_name.call());
 }

--- a/crates/bevy_mod_scripting_core/src/bindings/globals/core.rs
+++ b/crates/bevy_mod_scripting_core/src/bindings/globals/core.rs
@@ -87,13 +87,12 @@ impl CoreGlobals {
         let type_registry = type_registry.read();
         let mut type_cache = HashMap::<String, _>::default();
         for registration in type_registry.iter() {
-            if let Some(ident) = registration.type_info().type_path_table().ident() {
-                let registration = ScriptTypeRegistration::new(Arc::new(registration.clone()));
-                let registration = guard.clone().get_type_registration(registration)?;
-                let registration =
-                    registration.map_both(Val::from, |u| u.map_both(Val::from, Val::from));
-                type_cache.insert(ident.to_string(), registration);
-            }
+            let type_path = registration.type_info().type_path_table().short_path();
+            let registration = ScriptTypeRegistration::new(Arc::new(registration.clone()));
+            let registration = guard.clone().get_type_registration(registration)?;
+            let registration =
+                registration.map_both(Val::from, |u| u.map_both(Val::from, Val::from));
+            type_cache.insert(type_path.to_owned(), registration);
         }
 
         Ok(type_cache)

--- a/crates/testing_crates/script_integration_test_harness/src/lib.rs
+++ b/crates/testing_crates/script_integration_test_harness/src/lib.rs
@@ -38,33 +38,6 @@ fn dummy_startup_system<T>() {}
 fn dummy_before_post_update_system() {}
 fn dummy_post_update_system() {}
 
-pub trait Benchmarker: 'static + Send + Sync {
-    fn bench(
-        &self,
-        label: &str,
-        f: &dyn Fn() -> Result<ScriptValue, ScriptError>,
-    ) -> Result<ScriptValue, ScriptError>;
-
-    fn clone_box(&self) -> Box<dyn Benchmarker>;
-}
-
-#[derive(Clone)]
-pub struct NoOpBenchmarker;
-
-impl Benchmarker for NoOpBenchmarker {
-    fn bench(
-        &self,
-        _label: &str,
-        f: &dyn Fn() -> Result<ScriptValue, ScriptError>,
-    ) -> Result<ScriptValue, ScriptError> {
-        f()
-    }
-
-    fn clone_box(&self) -> Box<dyn Benchmarker> {
-        Box::new(self.clone())
-    }
-}
-
 #[derive(Event)]
 struct TestEventFinished;
 

--- a/crates/testing_crates/test_utils/src/test_data.rs
+++ b/crates/testing_crates/test_utils/src/test_data.rs
@@ -23,6 +23,20 @@ impl TestComponent {
     }
 }
 
+#[derive(Component, Reflect, PartialEq, Eq, Debug, Default)]
+#[reflect(Component)]
+pub struct GenericComponent<T: Default> {
+    pub value: T,
+}
+
+impl GenericComponent<String> {
+    pub fn init() -> Self {
+        Self {
+            value: "Initial Value".to_string(),
+        }
+    }
+}
+
 /// Test Resource with Reflect and ReflectResource registered
 #[derive(Resource, Reflect, Default, PartialEq, Eq, Debug)]
 #[reflect(Resource)]
@@ -278,11 +292,12 @@ impl_test_component_ids!(
         SimpleStruct => 6,
         SimpleTupleStruct => 7,
         SimpleEnum => 8,
+        GenericComponent<String> => 9,
     ],
     [
-        TestResource => 9,
-        ResourceWithDefault => 10,
-        TestResourceWithVariousFields => 11,
+        TestResource => 10,
+        ResourceWithDefault => 11,
+        TestResourceWithVariousFields => 12,
     ]
 );
 


### PR DESCRIPTION
# Summary
`types["GenericType<String>"]` should work now, this was using `ident` instead of `short_path` by mistake 
