### PR TITLE
fix: mdbook preprocessor links not taking into account root url

### DIFF
--- a/.github/workflows/bencher_on_pr_or_fork_upload.yml
+++ b/.github/workflows/bencher_on_pr_or_fork_upload.yml
@@ -49,6 +49,6 @@ jobs:
           --testbed linux-gha \
           --err \
           --adapter rust_criterion \
-          --github-actions '${{ secrets.GITHUB_TOKEN }}' \
+          --github-actions '${{ secrets.BENCHER_GITHUB_TOKEN }}' \
           --ci-number "$PR_NUMBER" \
           --file "$BENCHMARK_RESULTS"

--- a/.github/workflows/bencher_on_pr_or_fork_upload.yml
+++ b/.github/workflows/bencher_on_pr_or_fork_upload.yml
@@ -5,6 +5,8 @@ on:
     workflows: [Run benchmarks on PR]
     types: [completed]
 
+permissions: write-all
+
 jobs:
   track_fork_pr_branch:
     if: github.event.workflow_run.conclusion == 'success'

--- a/.github/workflows/bencher_on_pr_or_fork_upload.yml
+++ b/.github/workflows/bencher_on_pr_or_fork_upload.yml
@@ -49,6 +49,6 @@ jobs:
           --testbed linux-gha \
           --err \
           --adapter rust_criterion \
-          --github-actions '${{ secrets.BENCHER_GITHUB_TOKEN }}' \
+          --github-actions '${{ secrets.GITHUB_TOKEN }}' \
           --ci-number "$PR_NUMBER" \
           --file "$BENCHMARK_RESULTS"

--- a/crates/lad_backends/mdbook_lad_preprocessor/tests/books/example_ladfile/book.toml
+++ b/crates/lad_backends/mdbook_lad_preprocessor/tests/books/example_ladfile/book.toml
@@ -8,6 +8,6 @@ description = "Documentation for the Bevy Scripting library"
 
 
 [preprocessor.lad-preprocessor]
-
+root = "root"
 
 [output.markdown]

--- a/docs/book.toml
+++ b/docs/book.toml
@@ -16,3 +16,4 @@ enable = true
 level = 1
 
 [preprocessor.lad-preprocessor]
+root = "bevy_mod_scripting"


### PR DESCRIPTION
# Summary
- These were broken on the github.io url after I made the links absolute