### PR TITLE
fix: make all links in the mdbook preprocessor relative

### DIFF
--- a/crates/lad_backends/mdbook_lad_preprocessor/src/sections.rs
+++ b/crates/lad_backends/mdbook_lad_preprocessor/src/sections.rs
@@ -286,7 +286,7 @@ impl<'a> Section<'a> {
             }
             SectionData::InstancesSummary => {
                 let instances = self.ladfile.globals.iter().collect::<Vec<_>>();
-                let types_directory = PathBuf::from("/").join(self.parent_path.join("types"));
+                let types_directory = PathBuf::from("./types");
                 vec![SectionItem::InstancesSummary {
                     instances,
                     ladfile: self.ladfile,
@@ -355,7 +355,7 @@ impl<'a> Section<'a> {
                 ]
             }
             SectionData::FunctionDetail { function } => {
-                let types_directory = self.parent_path.join("../types");
+                let types_directory = PathBuf::from("../types");
                 vec![SectionItem::FunctionDetails {
                     function,
                     ladfile: self.ladfile,

--- a/crates/lad_backends/mdbook_lad_preprocessor/tests/books/example_ladfile/expected/parent/lad/functions/hello_world.md
+++ b/crates/lad_backends/mdbook_lad_preprocessor/tests/books/example_ladfile/expected/parent/lad/functions/hello_world.md
@@ -6,11 +6,11 @@
 
 | Name | Type | Documentation |
 | --- | --- | --- |
-| **arg1** | [usize](parent/lad/functions/../types/usize.md) | No Documentation 🚧 |
+| **arg1** | [usize](../types/usize.md) | No Documentation 🚧 |
 
 #### Returns
 
 | Name | Type | Documentation |
 | --- | --- | --- |
-| **arg0** | [usize](parent/lad/functions/../types/usize.md) | No Documentation 🚧 |
+| **arg0** | [usize](../types/usize.md) | No Documentation 🚧 |
 

--- a/crates/lad_backends/mdbook_lad_preprocessor/tests/books/example_ladfile/expected/parent/lad/globals.md
+++ b/crates/lad_backends/mdbook_lad_preprocessor/tests/books/example_ladfile/expected/parent/lad/globals.md
@@ -10,8 +10,8 @@ Instances containing actual accessible values\.
 
 | Instance | Type |
 | --- | --- |
-| `my_non_static_instance` | Vec\<[UnitType](/parent/lad/types/unittype.md)\> |
-| `map` | HashMap\<[String](/parent/lad/types/string.md), [String](/parent/lad/types/string.md) \| [String](/parent/lad/types/string.md)\> |
+| `my_non_static_instance` | Vec\<[UnitType](./types/unittype.md)\> |
+| `map` | HashMap\<[String](./types/string.md), [String](./types/string.md) \| [String](./types/string.md)\> |
 
 ### Static Instances
 
@@ -19,5 +19,5 @@ Static type references, existing for the purpose of typed static function calls\
 
 | Instance | Type |
 | --- | --- |
-| `my_static_instance` | StructType\<[usize](/parent/lad/types/usize.md)\> |
+| `my_static_instance` | StructType\<[usize](./types/usize.md)\> |
 


### PR DESCRIPTION
# Summary
- absolute links don't work that well, just switch back to relative ones
