### PR TITLE
feat: add `profile_with_tracy` feature which plays nicely with bevy's `bevy/trace_tracy` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,7 +88,7 @@ ladfile_builder = { path = "crates/ladfile_builder", version = "0.2.6" }
 script_integration_test_harness = { workspace = true }
 test_utils = { workspace = true }
 libtest-mimic = "0.8"
-tracing-tracy = "*"
+tracing-tracy = "0.11"
 
 [workspace]
 members = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,9 @@ rhai = ["bevy_mod_scripting_rhai", "bevy_mod_scripting_functions/rhai_bindings"]
 ## rune
 # rune = ["bevy_mod_scripting_rune"]
 
+### Profiling
+profile_with_tracy = ["bevy/trace_tracy"]
+
 [dependencies]
 bevy = { workspace = true }
 bevy_mod_scripting_core = { workspace = true }
@@ -85,6 +88,7 @@ ladfile_builder = { path = "crates/ladfile_builder", version = "0.2.6" }
 script_integration_test_harness = { workspace = true }
 test_utils = { workspace = true }
 libtest-mimic = "0.8"
+tracing-tracy = "*"
 
 [workspace]
 members = [

--- a/crates/bevy_mod_scripting_core/src/bindings/function/script_function.rs
+++ b/crates/bevy_mod_scripting_core/src/bindings/function/script_function.rs
@@ -103,7 +103,7 @@ impl DynamicScriptFunction {
         args: I,
         context: FunctionCallContext,
     ) -> Result<ScriptValue, InteropError> {
-        profiling::scope!("Dynamic Call ", self.name().to_string());
+        profiling::scope!("Dynamic Call ", self.name().deref());
         let args = args.into_iter().collect::<VecDeque<_>>();
         // should we be inlining call errors into the return value?
         let return_val = (self.func)(context, args);
@@ -159,7 +159,7 @@ impl DynamicScriptFunctionMut {
         args: I,
         context: FunctionCallContext,
     ) -> Result<ScriptValue, InteropError> {
-        profiling::scope!("Dynamic Call Mut", self.name().to_string());
+        profiling::scope!("Dynamic Call Mut", self.name().deref());
         let args = args.into_iter().collect::<VecDeque<_>>();
         // should we be inlining call errors into the return value?
         let mut write = self.func.write();

--- a/crates/testing_crates/script_integration_test_harness/src/lib.rs
+++ b/crates/testing_crates/script_integration_test_harness/src/lib.rs
@@ -318,6 +318,7 @@ pub fn run_lua_benchmark<M: criterion::measurement::Measurement>(
     label: &str,
     criterion: &mut criterion::BenchmarkGroup<M>,
 ) -> Result<(), String> {
+    use bevy::utils::tracing;
     use bevy_mod_scripting_lua::mlua::Function;
 
     let plugin = make_test_lua_plugin();
@@ -333,6 +334,7 @@ pub fn run_lua_benchmark<M: criterion::measurement::Measurement>(
                 if let Some(pre_bencher) = &pre_bencher {
                     pre_bencher.call::<()>(()).unwrap();
                 }
+                tracing::info_span!("profiling_iter", label);
                 c.iter(|| {
                     bencher.call::<()>(()).unwrap();
                 })
@@ -348,6 +350,7 @@ pub fn run_rhai_benchmark<M: criterion::measurement::Measurement>(
     label: &str,
     criterion: &mut criterion::BenchmarkGroup<M>,
 ) -> Result<(), String> {
+    use bevy::utils::tracing;
     use bevy_mod_scripting_rhai::rhai::Dynamic;
 
     let plugin = make_test_rhai_plugin();
@@ -367,6 +370,8 @@ pub fn run_rhai_benchmark<M: criterion::measurement::Measurement>(
                         .call_fn::<Dynamic>(&mut ctxt.scope, &ctxt.ast, "pre_bench", ARGS)
                         .unwrap();
                 }
+                tracing::info_span!("profiling_iter", label);
+
                 c.iter(|| {
                     let _ = runtime
                         .call_fn::<Dynamic>(&mut ctxt.scope, &ctxt.ast, "bench", ARGS)

--- a/crates/testing_crates/test_utils/src/test_data.rs
+++ b/crates/testing_crates/test_utils/src/test_data.rs
@@ -346,7 +346,7 @@ pub fn setup_integration_test<F: FnOnce(&mut World, &mut TypeRegistry)>(init: F)
         HierarchyPlugin,
         DiagnosticsPlugin,
         LogPlugin {
-            filter: "bevy_mod_scripting_core=debug".to_string(),
+            filter: "bevy_mod_scripting_core=trace".to_string(),
             ..Default::default()
         },
     ));


### PR DESCRIPTION
# Summary
Adds `xtask` utilities for profiling a specific benchmark, as well as a feature which plays nicely with bevy's.

I tried using an independent `profiling` setup but I think this one is the least confusing and most in line with what bevy consumers will already be familiar with