### PR TITLE
feat: improve tracing spans, add `profile_with_tracy` feature flag

### DIFF
--- a/.github/workflows/bencher_on_pr_or_fork_closed.yml
+++ b/.github/workflows/bencher_on_pr_or_fork_closed.yml
@@ -15,3 +15,4 @@ jobs:
           --project bms \
           --token '${{ secrets.BENCHER_API_TOKEN }}' \
           --branch "$GITHUB_HEAD_REF"
+        continue-on-error: true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,6 +89,7 @@ script_integration_test_harness = { workspace = true }
 test_utils = { workspace = true }
 libtest-mimic = "0.8"
 tracing-tracy = "0.11"
+regex = "1.11"
 
 [workspace]
 members = [

--- a/crates/bevy_mod_scripting_core/Cargo.toml
+++ b/crates/bevy_mod_scripting_core/Cargo.toml
@@ -33,7 +33,7 @@ bevy = { workspace = true, default-features = false, features = ["bevy_asset"] }
 thiserror = "1.0.31"
 parking_lot = "0.12.1"
 dashmap = "6"
-smallvec = "1.11"
+smallvec = { version = "1.11", features = ["union"] }
 itertools = "0.13"
 derivative = "2.2"
 profiling = { workspace = true }

--- a/crates/bevy_mod_scripting_core/src/asset.rs
+++ b/crates/bevy_mod_scripting_core/src/asset.rs
@@ -73,6 +73,7 @@ pub struct ScriptAssetLoader {
     pub preprocessor: Option<Box<dyn Fn(&mut [u8]) -> Result<(), ScriptError> + Send + Sync>>,
 }
 
+#[profiling::all_functions]
 impl AssetLoader for ScriptAssetLoader {
     type Asset = ScriptAsset;
 
@@ -121,6 +122,7 @@ pub struct ScriptAssetSettings {
     pub supported_extensions: &'static [&'static str],
 }
 
+#[profiling::all_functions]
 impl ScriptAssetSettings {
     /// Selects the language for a given asset path
     pub fn select_script_language(&self, path: &AssetPath) -> Language {
@@ -178,6 +180,7 @@ pub struct ScriptMetadata {
     pub language: Language,
 }
 
+#[profiling::all_functions]
 impl ScriptMetadataStore {
     /// Inserts a new metadata entry
     pub fn insert(&mut self, id: AssetId<ScriptAsset>, meta: ScriptMetadata) {
@@ -202,6 +205,7 @@ impl ScriptMetadataStore {
 }
 
 /// Converts incoming asset events, into internal script asset events, also loads and inserts metadata for newly added scripts
+#[profiling::function]
 pub(crate) fn dispatch_script_asset_events(
     mut events: EventReader<AssetEvent<ScriptAsset>>,
     mut script_asset_events: EventWriter<ScriptAssetEvent>,
@@ -256,6 +260,7 @@ pub(crate) fn dispatch_script_asset_events(
 }
 
 /// Listens to [`ScriptAssetEvent::Removed`] events and removes the corresponding script metadata.
+#[profiling::function]
 pub(crate) fn remove_script_metadata(
     mut events: EventReader<ScriptAssetEvent>,
     mut asset_path_map: ResMut<ScriptMetadataStore>,
@@ -273,6 +278,7 @@ pub(crate) fn remove_script_metadata(
 /// Listens to [`ScriptAssetEvent`] events and dispatches [`CreateOrUpdateScript`] and [`DeleteScript`] commands accordingly.
 ///
 /// Allows for hot-reloading of scripts.
+#[profiling::function]
 pub(crate) fn sync_script_data<P: IntoScriptPluginParams>(
     mut events: EventReader<ScriptAssetEvent>,
     script_assets: Res<Assets<ScriptAsset>>,
@@ -321,6 +327,7 @@ pub(crate) fn sync_script_data<P: IntoScriptPluginParams>(
 }
 
 /// Setup all the asset systems for the scripting plugin and the dependencies
+#[profiling::function]
 pub(crate) fn configure_asset_systems(app: &mut App) -> &mut App {
     // these should be in the same set as bevy's asset systems
     // currently this is in the PreUpdate set
@@ -348,6 +355,7 @@ pub(crate) fn configure_asset_systems(app: &mut App) -> &mut App {
 }
 
 /// Setup all the asset systems for the scripting plugin and the dependencies
+#[profiling::function]
 pub(crate) fn configure_asset_systems_for_plugin<P: IntoScriptPluginParams>(
     app: &mut App,
 ) -> &mut App {

--- a/crates/bevy_mod_scripting_core/src/bindings/function/from.rs
+++ b/crates/bevy_mod_scripting_core/src/bindings/function/from.rs
@@ -32,6 +32,7 @@ pub trait FromScript {
         Self: Sized;
 }
 
+#[profiling::all_functions]
 impl FromScript for ScriptValue {
     type This<'w> = Self;
     fn from_script(value: ScriptValue, _world: WorldGuard) -> Result<Self, InteropError> {
@@ -39,6 +40,7 @@ impl FromScript for ScriptValue {
     }
 }
 
+#[profiling::all_functions]
 impl FromScript for () {
     type This<'w> = Self;
     fn from_script(_value: ScriptValue, _world: WorldGuard) -> Result<Self, InteropError> {
@@ -46,6 +48,7 @@ impl FromScript for () {
     }
 }
 
+#[profiling::all_functions]
 impl FromScript for bool {
     type This<'w> = Self;
     #[profiling::function]
@@ -70,6 +73,7 @@ impl FromScript for bool {
 macro_rules! impl_from_with_downcast {
     ($($ty:ty),*) => {
         $(
+            #[profiling::all_functions]
             impl FromScript for $ty {
                 type This<'w> = Self;
                 #[profiling::function]
@@ -92,6 +96,7 @@ impl_from_with_downcast!(i8, i16, i32, i64, i128, u8, u16, u32, u64, u128, f32, 
 macro_rules! impl_from_stringlike {
     ($($ty:ty),*) => {
         $(
+            #[profiling::all_functions]
             impl FromScript for $ty {
                 type This<'w> = Self;
                 #[profiling::function]
@@ -109,6 +114,7 @@ macro_rules! impl_from_stringlike {
 
 impl_from_stringlike!(String, PathBuf, OsString);
 
+#[profiling::all_functions]
 impl FromScript for char {
     type This<'w> = Self;
     #[profiling::function]
@@ -133,6 +139,7 @@ impl FromScript for char {
     }
 }
 
+#[profiling::all_functions]
 impl FromScript for ReflectReference {
     type This<'w> = Self;
     #[profiling::function]
@@ -154,6 +161,7 @@ impl FromScript for ReflectReference {
 #[derive(Reflect)]
 pub struct Val<T>(pub T);
 
+#[profiling::all_functions]
 impl<T> Val<T> {
     /// Create a new `Val` with the given value.
     pub fn new(value: T) -> Self {
@@ -186,6 +194,7 @@ impl<T> From<T> for Val<T> {
     }
 }
 
+#[profiling::all_functions]
 impl<T: FromReflect> FromScript for Val<T> {
     type This<'w> = Self;
     #[profiling::function]
@@ -230,6 +239,7 @@ impl<T> Deref for Ref<'_, T> {
     }
 }
 
+#[profiling::all_functions]
 impl<T: FromReflect> FromScript for Ref<'_, T> {
     type This<'a> = Ref<'a, T>;
     #[profiling::function]
@@ -302,6 +312,7 @@ impl<'a, T> From<&'a mut T> for Mut<'a, T> {
     }
 }
 
+#[profiling::all_functions]
 impl<T: FromReflect> FromScript for Mut<'_, T> {
     type This<'w> = Mut<'w, T>;
     #[profiling::function]
@@ -337,6 +348,7 @@ impl<T: FromReflect> FromScript for Mut<'_, T> {
     }
 }
 
+#[profiling::all_functions]
 impl<T: FromScript> FromScript for Option<T>
 where
     for<'w> T::This<'w>: Into<T>,
@@ -351,6 +363,7 @@ where
     }
 }
 
+#[profiling::all_functions]
 impl<T: FromScript + 'static> FromScript for Vec<T>
 where
     for<'w> T::This<'w>: Into<T>,
@@ -374,6 +387,7 @@ where
     }
 }
 
+#[profiling::all_functions]
 impl<T: FromScript + 'static, const N: usize> FromScript for [T; N]
 where
     for<'w> T::This<'w>: Into<T>,
@@ -399,6 +413,7 @@ where
     }
 }
 
+#[profiling::all_functions]
 impl FromScript for DynamicScriptFunctionMut {
     type This<'w> = Self;
     #[profiling::function]
@@ -416,6 +431,7 @@ impl FromScript for DynamicScriptFunctionMut {
     }
 }
 
+#[profiling::all_functions]
 impl FromScript for DynamicScriptFunction {
     type This<'w> = Self;
     #[profiling::function]
@@ -433,6 +449,7 @@ impl FromScript for DynamicScriptFunction {
     }
 }
 
+#[profiling::all_functions]
 impl<V> FromScript for std::collections::HashMap<String, V>
 where
     V: FromScript + 'static,
@@ -468,6 +485,7 @@ where
 /// A union of two or more (by nesting unions) types.
 pub struct Union<T1, T2>(Result<T1, T2>);
 
+#[profiling::all_functions]
 impl<T1, T2> Union<T1, T2> {
     /// Create a new union with the left value.
     pub fn new_left(value: T1) -> Self {
@@ -478,7 +496,6 @@ impl<T1, T2> Union<T1, T2> {
     pub fn new_right(value: T2) -> Self {
         Union(Err(value))
     }
-
 
     /// Try interpret the union as the left type
     pub fn into_left(self) -> Result<T1, T2> {
@@ -495,7 +512,7 @@ impl<T1, T2> Union<T1, T2> {
             Ok(l) => Err(l),
         }
     }
-     
+
     /// Map the union to another type
     pub fn map_both<U1, U2, F: Fn(T1) -> U1, G: Fn(T2) -> U2>(self, f: F, g: G) -> Union<U1, U2> {
         match self.0 {
@@ -505,6 +522,7 @@ impl<T1, T2> Union<T1, T2> {
     }
 }
 
+#[profiling::all_functions]
 impl<T1: FromScript, T2: FromScript> FromScript for Union<T1, T2>
 where
     for<'a> T1::This<'a>: Into<T1>,
@@ -530,6 +548,7 @@ where
 macro_rules! impl_from_script_tuple {
     ($($ty:ident),*) => {
         #[allow(non_snake_case)]
+        #[profiling::all_functions]
         impl<$($ty: FromScript),*> FromScript for ($($ty,)*)
         where
             Self: 'static,

--- a/crates/bevy_mod_scripting_core/src/bindings/function/into_ref.rs
+++ b/crates/bevy_mod_scripting_core/src/bindings/function/into_ref.rs
@@ -54,6 +54,7 @@ macro_rules! downcast_into_value {
     };
 }
 
+#[profiling::all_functions]
 impl IntoScriptRef for ReflectReference {
     #[profiling::function]
     fn into_script_ref(
@@ -63,6 +64,7 @@ impl IntoScriptRef for ReflectReference {
         self_.with_reflect(world.clone(), |r| into_script_ref(self_.clone(), r, world))?
     }
 }
+
 #[profiling::function]
 fn into_script_ref(
     mut self_: ReflectReference,

--- a/crates/bevy_mod_scripting_core/src/bindings/function/namespace.rs
+++ b/crates/bevy_mod_scripting_core/src/bindings/function/namespace.rs
@@ -44,6 +44,7 @@ impl<T: ?Sized + 'static> IntoNamespace for T {
 }
 
 /// A type which implements [`IntoNamespace`] by always converting to the global namespace
+#[profiling::all_functions]
 impl Namespace {
     /// Returns the prefix for this namespace
     pub fn prefix(self) -> Cow<'static, str> {
@@ -70,6 +71,7 @@ pub struct NamespaceBuilder<'a, N> {
     pub world: &'a mut World,
 }
 
+#[profiling::all_functions]
 impl<'a, S: IntoNamespace> NamespaceBuilder<'a, S> {
     /// Creates a new `NamespaceBuilder` that will register functions in the namespace corresponding to the given type
     /// It will also register the type itself in the type registry.

--- a/crates/bevy_mod_scripting_core/src/bindings/globals/core.rs
+++ b/crates/bevy_mod_scripting_core/src/bindings/globals/core.rs
@@ -26,11 +26,13 @@ pub struct CoreScriptGlobalsPlugin;
 impl Plugin for CoreScriptGlobalsPlugin {
     fn build(&self, _app: &mut bevy::app::App) {}
     fn finish(&self, app: &mut bevy::app::App) {
+        profiling::function_scope!("app finish");
         register_static_core_globals(app.world_mut());
         register_core_globals(app.world_mut());
     }
 }
 
+#[profiling::function]
 fn register_static_core_globals(world: &mut bevy::ecs::world::World) {
     let global_registry = world
         .get_resource_or_init::<AppScriptGlobalsRegistry>()
@@ -83,6 +85,7 @@ impl CoreGlobals {
         >,
         InteropError,
     > {
+        profiling::function_scope!("registering core globals");
         let type_registry = guard.type_registry();
         let type_registry = type_registry.read();
         let mut type_cache = HashMap::<String, _>::default();

--- a/crates/bevy_mod_scripting_core/src/bindings/globals/mod.rs
+++ b/crates/bevy_mod_scripting_core/src/bindings/globals/mod.rs
@@ -21,6 +21,7 @@ crate::private::export_all_in_modules! {
 #[derive(Default, Resource, Clone)]
 pub struct AppScriptGlobalsRegistry(Arc<RwLock<ScriptGlobalsRegistry>>);
 
+#[profiling::all_functions]
 impl AppScriptGlobalsRegistry {
     /// Returns a reference to the inner [`ScriptGlobalsRegistry`].
     pub fn read(&self) -> RwLockReadGuard<ScriptGlobalsRegistry> {
@@ -69,6 +70,7 @@ pub struct ScriptGlobalsRegistry {
     dummies: HashMap<Cow<'static, str>, ScriptGlobalDummy>,
 }
 
+#[profiling::all_functions]
 impl ScriptGlobalsRegistry {
     /// Gets the global with the given name
     pub fn get(&self, name: &str) -> Option<&ScriptGlobal> {

--- a/crates/bevy_mod_scripting_core/src/bindings/query.rs
+++ b/crates/bevy_mod_scripting_core/src/bindings/query.rs
@@ -47,6 +47,7 @@ pub struct ScriptResourceRegistration {
     pub(crate) resource_id: ComponentId,
 }
 
+#[profiling::all_functions]
 impl ScriptTypeRegistration {
     /// Creates a new [`ScriptTypeRegistration`] from a [`TypeRegistration`].
     pub fn new(registration: Arc<TypeRegistration>) -> Self {
@@ -76,6 +77,8 @@ impl ScriptTypeRegistration {
         &self.registration
     }
 }
+
+#[profiling::all_functions]
 impl ScriptResourceRegistration {
     /// Creates a new [`ScriptResourceRegistration`] from a [`ScriptTypeRegistration`] and a [`ComponentId`].
     pub fn new(registration: ScriptTypeRegistration, resource_id: ComponentId) -> Self {
@@ -102,6 +105,7 @@ impl ScriptResourceRegistration {
     }
 }
 
+#[profiling::all_functions]
 impl ScriptComponentRegistration {
     /// Creates a new [`ScriptComponentRegistration`] from a [`ScriptTypeRegistration`] and a [`ComponentId`].
     pub fn new(registration: ScriptTypeRegistration, component_id: ComponentId) -> Self {
@@ -250,6 +254,7 @@ pub struct ScriptQueryBuilder {
     without: Vec<ScriptComponentRegistration>,
 }
 
+#[profiling::all_functions]
 impl ScriptQueryBuilder {
     /// Adds components to the query.
     pub fn components(&mut self, components: Vec<ScriptComponentRegistration>) -> &mut Self {

--- a/crates/bevy_mod_scripting_core/src/bindings/schedule.rs
+++ b/crates/bevy_mod_scripting_core/src/bindings/schedule.rs
@@ -44,6 +44,7 @@ pub struct ScheduleRegistry {
     schedules: HashMap<TypeId, ReflectSchedule>,
 }
 
+#[profiling::all_functions]
 impl ScheduleRegistry {
     /// Creates a new schedule registry containing all default bevy schedules.
     pub fn new() -> Self {

--- a/crates/bevy_mod_scripting_core/src/bindings/script_component.rs
+++ b/crates/bevy_mod_scripting_core/src/bindings/script_component.rs
@@ -37,6 +37,7 @@ impl Component for DynamicComponent {
 #[derive(Clone, Resource, Default)]
 pub struct AppScriptComponentRegistry(pub Arc<RwLock<ScriptComponentRegistry>>);
 
+#[profiling::all_functions]
 impl AppScriptComponentRegistry {
     /// Reads the underlying registry
     pub fn read(&self) -> parking_lot::RwLockReadGuard<ScriptComponentRegistry> {
@@ -55,6 +56,7 @@ pub struct ScriptComponentRegistry {
     components: HashMap<String, DynamicComponentInfo>,
 }
 
+#[profiling::all_functions]
 impl ScriptComponentRegistry {
     /// Registers a dynamic script component, possibly overwriting an existing one
     pub fn register(&mut self, info: DynamicComponentInfo) {
@@ -67,6 +69,7 @@ impl ScriptComponentRegistry {
     }
 }
 
+#[profiling::all_functions]
 impl WorldAccessGuard<'_> {
     /// Registers a dynamic script component, and returns a reference to its registration
     pub fn register_script_component(

--- a/crates/bevy_mod_scripting_core/src/bindings/script_system.rs
+++ b/crates/bevy_mod_scripting_core/src/bindings/script_system.rs
@@ -49,6 +49,7 @@ impl std::fmt::Debug for ScriptSystemSet {
     }
 }
 
+#[profiling::all_functions]
 impl ScriptSystemSet {
     /// Creates a new script system set
     pub fn new(id: impl Into<Cow<'static, str>>) -> Self {
@@ -56,6 +57,7 @@ impl ScriptSystemSet {
     }
 }
 
+#[profiling::all_functions]
 impl SystemSet for ScriptSystemSet {
     fn dyn_clone(&self) -> bevy::ecs::label::Box<dyn SystemSet> {
         Box::new(self.clone())
@@ -88,6 +90,7 @@ pub struct ScriptSystemBuilder {
     is_exclusive: bool,
 }
 
+#[profiling::all_functions]
 impl ScriptSystemBuilder {
     /// Creates a new script system builder
     pub fn new(name: CallbackLabel, script_id: ScriptId) -> Self {
@@ -197,6 +200,7 @@ struct DynamicHandlerContext<'w, P: IntoScriptPluginParams> {
     runtime_container: &'w RuntimeContainer<P>,
 }
 
+#[profiling::all_functions]
 impl<'w, P: IntoScriptPluginParams> DynamicHandlerContext<'w, P> {
     #[allow(
         clippy::expect_used,
@@ -345,6 +349,7 @@ pub struct DynamicScriptSystem<P: IntoScriptPluginParams> {
 /// A marker type distinguishing between vanilla and script system types
 pub struct IsDynamicScriptSystem<P>(PhantomData<fn() -> P>);
 
+#[profiling::all_functions]
 impl<P: IntoScriptPluginParams> IntoSystem<(), (), IsDynamicScriptSystem<P>>
     for ScriptSystemBuilder
 {
@@ -366,6 +371,7 @@ impl<P: IntoScriptPluginParams> IntoSystem<(), (), IsDynamicScriptSystem<P>>
     }
 }
 
+#[profiling::all_functions]
 impl<P: IntoScriptPluginParams> System for DynamicScriptSystem<P> {
     type In = ();
 

--- a/crates/bevy_mod_scripting_core/src/bindings/script_value.rs
+++ b/crates/bevy_mod_scripting_core/src/bindings/script_value.rs
@@ -41,6 +41,7 @@ pub enum ScriptValue {
     Error(InteropError),
 }
 
+#[profiling::all_functions]
 impl ScriptValue {
     /// Returns the contained string if this is a string variant otherwise returns the original value.
     pub fn as_string(self) -> Result<Cow<'static, str>, Self> {
@@ -68,66 +69,77 @@ impl ScriptValue {
     }
 }
 
+#[profiling::all_functions]
 impl From<()> for ScriptValue {
     fn from(_: ()) -> Self {
         ScriptValue::Unit
     }
 }
 
+#[profiling::all_functions]
 impl From<bool> for ScriptValue {
     fn from(value: bool) -> Self {
         ScriptValue::Bool(value)
     }
 }
 
+#[profiling::all_functions]
 impl From<i64> for ScriptValue {
     fn from(value: i64) -> Self {
         ScriptValue::Integer(value)
     }
 }
 
+#[profiling::all_functions]
 impl From<f64> for ScriptValue {
     fn from(value: f64) -> Self {
         ScriptValue::Float(value)
     }
 }
 
+#[profiling::all_functions]
 impl From<&'static str> for ScriptValue {
     fn from(value: &'static str) -> Self {
         ScriptValue::String(value.into())
     }
 }
 
+#[profiling::all_functions]
 impl From<String> for ScriptValue {
     fn from(value: String) -> Self {
         ScriptValue::String(value.into())
     }
 }
 
+#[profiling::all_functions]
 impl From<Cow<'static, str>> for ScriptValue {
     fn from(value: Cow<'static, str>) -> Self {
         ScriptValue::String(value)
     }
 }
 
+#[profiling::all_functions]
 impl From<Vec<ScriptValue>> for ScriptValue {
     fn from(value: Vec<ScriptValue>) -> Self {
         ScriptValue::List(value)
     }
 }
 
+#[profiling::all_functions]
 impl From<ReflectReference> for ScriptValue {
     fn from(value: ReflectReference) -> Self {
         ScriptValue::Reference(value)
     }
 }
 
+#[profiling::all_functions]
 impl From<InteropError> for ScriptValue {
     fn from(value: InteropError) -> Self {
         ScriptValue::Error(value)
     }
 }
 
+#[profiling::all_functions]
 impl<T: Into<ScriptValue>> From<Option<T>> for ScriptValue {
     fn from(value: Option<T>) -> Self {
         match value {
@@ -137,6 +149,7 @@ impl<T: Into<ScriptValue>> From<Option<T>> for ScriptValue {
     }
 }
 
+#[profiling::all_functions]
 impl<T: Into<ScriptValue>, E: Into<InteropError>> From<Result<T, E>> for ScriptValue {
     fn from(value: Result<T, E>) -> Self {
         match value {

--- a/crates/bevy_mod_scripting_core/src/bindings/world.rs
+++ b/crates/bevy_mod_scripting_core/src/bindings/world.rs
@@ -93,6 +93,7 @@ impl std::fmt::Debug for WorldAccessGuardInner<'_> {
     }
 }
 
+#[profiling::all_functions]
 impl WorldAccessGuard<'static> {
     /// Shortens the lifetime of the guard to the given lifetime.
     pub(crate) fn shorten_lifetime<'w>(self) -> WorldGuard<'w> {
@@ -241,6 +242,11 @@ impl<'w> WorldAccessGuard<'w> {
     /// Purely debugging utility to list all accesses currently held.
     pub fn list_accesses(&self) -> Vec<(ReflectAccessId, AccessCount)> {
         self.inner.accesses.list_accesses()
+    }
+
+    /// Should only really be used for testing purposes
+    pub unsafe fn release_all_accesses(&self) {
+        self.inner.accesses.release_all_accesses();
     }
 
     /// Returns the number of accesses currently held.

--- a/crates/bevy_mod_scripting_core/src/commands.rs
+++ b/crates/bevy_mod_scripting_core/src/commands.rs
@@ -94,6 +94,7 @@ pub struct CreateOrUpdateScript<P: IntoScriptPluginParams> {
     _ph: std::marker::PhantomData<fn(P::R, P::C)>,
 }
 
+#[profiling::all_functions]
 impl<P: IntoScriptPluginParams> CreateOrUpdateScript<P> {
     /// Creates a new CreateOrUpdateScript command with the given ID, content and asset
     pub fn new(id: ScriptId, content: Box<[u8]>, asset: Option<Handle<ScriptAsset>>) -> Self {
@@ -169,6 +170,7 @@ impl<P: IntoScriptPluginParams> CreateOrUpdateScript<P> {
     }
 }
 
+#[profiling::all_functions]
 impl<P: IntoScriptPluginParams> Command for CreateOrUpdateScript<P> {
     fn apply(self, world: &mut bevy::prelude::World) {
         with_handler_system_state(world, |guard, handler_ctxt: &mut HandlerContext<P>| {
@@ -293,6 +295,7 @@ impl RemoveStaticScript {
     }
 }
 
+#[profiling::all_functions]
 impl Command for RemoveStaticScript {
     fn apply(self, world: &mut bevy::prelude::World) {
         let mut static_scripts = world.get_resource_or_init::<StaticScripts>();

--- a/crates/bevy_mod_scripting_core/src/docgen/info.rs
+++ b/crates/bevy_mod_scripting_core/src/docgen/info.rs
@@ -34,6 +34,7 @@ impl Default for FunctionInfo {
     }
 }
 
+#[profiling::all_functions]
 impl FunctionInfo {
     /// Create a new function info with default values.
     pub fn new() -> Self {
@@ -108,6 +109,7 @@ pub struct FunctionArgInfo {
     pub type_info: Option<ThroughTypeInfo>,
 }
 
+#[profiling::all_functions]
 impl FunctionArgInfo {
     /// Create a new function argument info with a name.
     pub fn with_name(mut self, name: Cow<'static, str>) -> Self {
@@ -145,6 +147,7 @@ impl Default for FunctionReturnInfo {
     }
 }
 
+#[profiling::all_functions]
 impl FunctionReturnInfo {
     /// Create a new function return info for a specific type.
     pub fn new_for<T: TypedThrough + 'static>() -> Self {
@@ -157,6 +160,7 @@ impl FunctionReturnInfo {
 
 macro_rules! impl_documentable {
     ($( $param:ident ),*) => {
+        #[profiling::all_functions]
         impl<$($param,)* F, O> GetFunctionInfo<fn($($param),*) -> O> for F
             where
             F: Fn($($param),*) -> O,

--- a/crates/bevy_mod_scripting_core/src/lib.rs
+++ b/crates/bevy_mod_scripting_core/src/lib.rs
@@ -117,6 +117,7 @@ impl<P: IntoScriptPluginParams> Default for ScriptingPlugin<P> {
     }
 }
 
+#[profiling::all_functions]
 impl<P: IntoScriptPluginParams> Plugin for ScriptingPlugin<P> {
     fn build(&self, app: &mut bevy::prelude::App) {
         app.insert_resource(self.runtime_settings.clone())

--- a/crates/bevy_mod_scripting_core/src/runtime.rs
+++ b/crates/bevy_mod_scripting_core/src/runtime.rs
@@ -52,6 +52,7 @@ impl<P: IntoScriptPluginParams> Default for RuntimeContainer<P> {
     }
 }
 
+#[profiling::function]
 pub(crate) fn initialize_runtime<P: IntoScriptPluginParams>(
     runtime: ResMut<RuntimeContainer<P>>,
     settings: Res<RuntimeSettings<P>>,

--- a/crates/bevy_mod_scripting_core/src/script.rs
+++ b/crates/bevy_mod_scripting_core/src/script.rs
@@ -39,6 +39,7 @@ pub struct Scripts<P: IntoScriptPluginParams> {
     pub(crate) scripts: HashMap<ScriptId, Script<P>>,
 }
 
+#[profiling::all_functions]
 impl<P: IntoScriptPluginParams> Scripts<P> {
     /// Inserts a script into the collection
     pub fn insert(&mut self, script: Script<P>) {
@@ -113,6 +114,7 @@ pub struct StaticScripts {
     pub(crate) scripts: HashSet<ScriptId>,
 }
 
+#[profiling::all_functions]
 impl StaticScripts {
     /// Inserts a static script into the collection
     pub fn insert<S: Into<ScriptId>>(&mut self, script: S) {

--- a/crates/testing_crates/script_integration_test_harness/src/test_functions.rs
+++ b/crates/testing_crates/script_integration_test_harness/src/test_functions.rs
@@ -27,10 +27,12 @@ use rand_chacha::ChaCha12Rng;
 use test_utils::test_data::EnumerateTestComponents;
 
 // lazy lock rng state
-static RNG: std::sync::LazyLock<Mutex<ChaCha12Rng>> = std::sync::LazyLock::new(|| {
+pub static RNG: std::sync::LazyLock<Mutex<ChaCha12Rng>> = std::sync::LazyLock::new(|| {
     let seed = [42u8; 32];
     Mutex::new(ChaCha12Rng::from_seed(seed))
 });
+
+pub use rand;
 
 pub fn register_test_functions(world: &mut App) {
     let world = world.world_mut();

--- a/crates/testing_crates/test_utils/src/lib.rs
+++ b/crates/testing_crates/test_utils/src/lib.rs
@@ -45,7 +45,7 @@ fn visit_dirs(dir: &Path, cb: &mut dyn FnMut(&DirEntry)) -> io::Result<()> {
     Ok(())
 }
 
-pub fn discover_all_tests(manifest_dir: PathBuf, filter: impl Fn(&Path) -> bool) -> Vec<Test> {
+pub fn discover_all_tests(manifest_dir: PathBuf, filter: impl Fn(&Test) -> bool) -> Vec<Test> {
     let assets_root = manifest_dir.join("assets");
     let mut test_files = Vec::new();
     visit_dirs(&assets_root, &mut |entry| {
@@ -60,13 +60,15 @@ pub fn discover_all_tests(manifest_dir: PathBuf, filter: impl Fn(&Path) -> bool)
         {
             // only take the path from the assets  bit
             let relative = path.strip_prefix(&assets_root).unwrap();
-            if !filter(relative) {
-                return;
-            }
-            test_files.push(Test {
+            let test = Test {
                 path: relative.to_path_buf(),
                 kind,
-            });
+            };
+
+            if !filter(&test) {
+                return;
+            }
+            test_files.push(test);
         }
     })
     .unwrap();

--- a/tests/script_tests.rs
+++ b/tests/script_tests.rs
@@ -46,7 +46,7 @@ fn main() {
     let args = Arguments::from_args();
     let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
 
-    let tests = discover_all_tests(manifest_dir, |p| p.starts_with("tests"))
+    let tests = discover_all_tests(manifest_dir, |p| p.path.starts_with("tests"))
         .into_iter()
         .map(|t| Trial::test(t.name(), move || t.execute()))
         .collect::<Vec<_>>();


### PR DESCRIPTION
# Summary
Overhauls tracing spans allowing neat visualisations like this one:
![image](https://github.com/user-attachments/assets/fcc62e04-7b6e-46e0-9a32-eb14dc4a1459)

At the same time, expands benchmarks to cover ground on "marshalling" teritory, which seems to be a large bottleneck in performance.

Also adds utilities to xtask to allow seamless tracing of BMS benchmarks with `tracy`
