### PR TITLE
perf: switch to hashbrown hashmap in the function registry

### DIFF
--- a/crates/bevy_mod_scripting_core/src/bindings/allocator.rs
+++ b/crates/bevy_mod_scripting_core/src/bindings/allocator.rs
@@ -6,12 +6,12 @@ use bevy::{
     ecs::system::{Res, Resource},
     prelude::ResMut,
     reflect::PartialReflect,
+    utils::hashbrown::HashMap,
 };
 use parking_lot::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 use std::{
     cell::UnsafeCell,
     cmp::Ordering,
-    collections::HashMap,
     fmt::{Display, Formatter},
     hash::Hasher,
     sync::{atomic::AtomicU64, Arc},

--- a/crates/bevy_mod_scripting_core/src/bindings/function/script_function.rs
+++ b/crates/bevy_mod_scripting_core/src/bindings/function/script_function.rs
@@ -11,9 +11,10 @@ use crate::{
     ScriptValue,
 };
 use bevy::prelude::{Reflect, Resource};
+use bevy::utils::hashbrown::HashMap;
 use parking_lot::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 use std::borrow::Cow;
-use std::collections::{HashMap, VecDeque};
+use std::collections::VecDeque;
 use std::hash::Hash;
 use std::ops::{Deref, DerefMut};
 use std::sync::Arc;


### PR DESCRIPTION
# Summary
The function registry as well as the allocator used the standard `std` hashmap, which by default uses a secure but slow hash. We don't need to worry about security here, so switching to hashbrown should give us a fair bit of speed up for free.
