### PR TITLE
feat: add option to emit response event on each callback  & `RunScriptCallback` command for "once-off" callbacks

### DIFF
--- a/crates/bevy_mod_scripting_core/src/lib.rs
+++ b/crates/bevy_mod_scripting_core/src/lib.rs
@@ -23,7 +23,7 @@ use context::{
     ContextPreHandlingInitializer,
 };
 use error::ScriptError;
-use event::ScriptCallbackEvent;
+use event::{ScriptCallbackEvent, ScriptCallbackResponseEvent};
 use handler::{CallbackSettings, HandlerFn};
 use runtime::{initialize_runtime, Runtime, RuntimeContainer, RuntimeInitializer, RuntimeSettings};
 use script::{ScriptComponent, ScriptId, Scripts, StaticScripts};
@@ -302,6 +302,7 @@ fn once_per_app_init(app: &mut App) {
 
     app.add_event::<ScriptErrorEvent>()
         .add_event::<ScriptCallbackEvent>()
+        .add_event::<ScriptCallbackResponseEvent>()
         .init_resource::<AppReflectAllocator>()
         .init_resource::<StaticScripts>()
         .init_asset::<ScriptAsset>()


### PR DESCRIPTION
# Summary

Largely, this is a refactor of the `commands` module, we now use a shared command `RunScriptCallback` to initiate internal callbacks. This command can also be used by consumers of BMS removing the need to have a full blown system to initiate one off callbacks.

At the same time, this adds a `trigger_response` field to the script callback event, when this is set to true:
- Event handlers will emit a `ScriptCallbackResponseEvent` with the response payload from the script
- Just as the `RunScriptCallback` command will do the same

This should give users more flexibility in running "once-off" callbacks, especially if they require scripts to output something from them. At the moment the best bet is to either:
- have an event handler in a temporary schedule
- run custom logic with event handler state
