### PR TITLE
perf: reduces size of `ScriptValue` to 64 bytes, moves some dynamic function methods into function info

### DIFF
--- a/crates/bevy_mod_scripting_core/src/docgen/info.rs
+++ b/crates/bevy_mod_scripting_core/src/docgen/info.rs
@@ -58,6 +58,18 @@ impl FunctionInfo {
         }
     }
 
+    /// Set the name of the function info.
+    pub fn with_name(mut self, name: impl Into<Cow<'static, str>>) -> Self {
+        self.name = name.into();
+        self
+    }
+
+    /// Set the namespace of the function info.
+    pub fn with_namespace(mut self, namespace: Namespace) -> Self {
+        self.namespace = namespace;
+        self
+    }
+
     /// Add an argument to the function info.
     pub fn add_arg<T: ArgMeta + TypedThrough + 'static>(
         mut self,


### PR DESCRIPTION
# Summary
Before this the size of `ScriptValue` was 168 bytes, this is a reduction of ~2.5x, which should reduce cache pressure and help with cloning/conversion performance 