### PR TITLE
refactor: refactor `ReflectReference` internally

### DIFF
--- a/crates/bevy_mod_scripting_core/src/bindings/pretty_print.rs
+++ b/crates/bevy_mod_scripting_core/src/bindings/pretty_print.rs
@@ -123,7 +123,7 @@ impl ReflectReferencePrinter {
     }
 
     fn pretty_print_base(base: &ReflectBaseType, world: Option<WorldGuard>, out: &mut String) {
-        let type_id = base.type_id;
+        let type_id = base.type_id();
         let type_path = if let Some(world) = world {
             type_id.display_with_world(world.clone())
         } else {


### PR DESCRIPTION
# Summary
Cleans the code up a bit, moves reflect base constructors into that type, and guarantees that typeid always corresponds to a valid reflect type 