### PR TITLE
fix: Derive `GetTypeDependency` without explicit "core" dependency.

### DIFF
--- a/crates/bevy_mod_scripting_derive/src/derive/get_type_dependencies.rs
+++ b/crates/bevy_mod_scripting_derive/src/derive/get_type_dependencies.rs
@@ -119,7 +119,7 @@ struct Args {
 
 impl Args {
     fn parse(attrs: &[syn::Attribute]) -> syn::Result<Self> {
-        let mut bms_core_path = parse_quote!(bevy_mod_scripting_core);
+        let mut bms_core_path = parse_quote!(::bevy_mod_scripting::core);
         let mut underlying = None;
         let mut dont_recurse = false;
 


### PR DESCRIPTION
# Problem 

The derive macro `GetTypeDependencies` required the `bevy_mod_scripting_core` to be an explicit dependency for users. 

# Solution
I altered it to refer to `::bevy_mod_scripting::core` instead of `bevy_mod_scripting_core` so that it works with the usual dependency of `bevy_mod_scripting`.

# Alternative

The user can add "bevy_mod_scripting_core" as a dependency.

## Testing
- It works in my project now.
- I did not add a test.
- I did run the tests; there were two unrelated failures that I looked into but it wasn't clear to me how to fix it.
```
error[E0433]: failed to resolve: could not find `function_scope` in `profiling`
  --> crates/bevy_mod_scripting_core/src/bindings/globals/core.rs:29:20
   |
29 |         profiling::function_scope!("app finish");
   |                    ^^^^^^^^^^^^^^ could not find `function_scope` in `profiling`

error[E0433]: failed to resolve: could not find `function_scope` in `profiling`
  --> crates/bevy_mod_scripting_core/src/bindings/globals/core.rs:88:20
   |
88 |         profiling::function_scope!("registering core globals");
   |                    ^^^^^^^^^^^^^^ could not find `function_scope` in `profiling`
```