### PR TITLE
feat: improve errors when entity is unavailable

### DIFF
--- a/assets/tests/insert_children/invalid_entity_errors.lua
+++ b/assets/tests/insert_children/invalid_entity_errors.lua
@@ -1,4 +1,4 @@
-local fake_entity = Entity.from_raw(9999)
+local fake_entity = Entity.from_raw(0)
 
 assert_throws(function()
     world.insert_children(fake_entity, 1, {fake_entity})

--- a/assets/tests/insert_children/invalid_entity_errors.lua
+++ b/assets/tests/insert_children/invalid_entity_errors.lua
@@ -1,10 +1,11 @@
 local fake_entity = Entity.from_raw(0)
+local fake_entity_valid = Entity.from_raw(9999)
 
 assert_throws(function()
-    world.insert_children(fake_entity, 1, {fake_entity})
+    world.insert_children(fake_entity_valid, 1, {fake_entity_valid})
 end, "Missing or invalid entity")
 
 local entity = world.spawn()
 assert_throws(function()
     world.insert_children(entity, 1, {fake_entity})
-end, "Missing or invalid entity")
+end, "Are you trying to use an entity in a callback in which it's unavailable?")

--- a/assets/tests/insert_children/invalid_entity_errors.rhai
+++ b/assets/tests/insert_children/invalid_entity_errors.rhai
@@ -1,10 +1,11 @@
 let fake_entity = Entity.from_raw.call(0);
+let fake_entity_valid = Entity.from_raw.call(9999);
 
 assert_throws(||{
-    world.insert_children.call(fake_entity, 0, [fake_entity]);
+    world.insert_children.call(fake_entity_valid, 0, [fake_entity_valid]);
 }, "Missing or invalid entity");
 
 let entity = world.spawn_.call();
 assert_throws(||{
     world.insert_children.call(entity, 0, [fake_entity]);
-}, "Missing or invalid entity");
+}, "Are you trying to use an entity in a callback in which it's unavailable?");

--- a/assets/tests/insert_children/invalid_entity_errors.rhai
+++ b/assets/tests/insert_children/invalid_entity_errors.rhai
@@ -1,4 +1,4 @@
-let fake_entity = Entity.from_raw.call(9999);
+let fake_entity = Entity.from_raw.call(0);
 
 assert_throws(||{
     world.insert_children.call(fake_entity, 0, [fake_entity]);

--- a/crates/bevy_mod_scripting_core/src/bindings/world.rs
+++ b/crates/bevy_mod_scripting_core/src/bindings/world.rs
@@ -536,7 +536,7 @@ impl<'w> WorldAccessGuard<'w> {
     /// checks if a given entity exists and is valid
     pub fn is_valid_entity(&self, entity: Entity) -> Result<bool, InteropError> {
         let cell = self.as_unsafe_world_cell()?;
-        Ok(cell.get_entity(entity).is_some())
+        Ok(cell.get_entity(entity).is_some() && entity.index() != 0)
     }
 
     /// Tries to call a fitting overload of the function with the given name and in the type id's namespace based on the arguments provided.

--- a/crates/bevy_mod_scripting_core/src/error.rs
+++ b/crates/bevy_mod_scripting_core/src/error.rs
@@ -1169,7 +1169,13 @@ macro_rules! invalid_index {
 
 macro_rules! missing_entity {
     ($entity:expr) => {
-        format!("Missing or invalid entity: {}", $entity)
+        {
+            if ($entity.index() == 0) {
+                format!("Invalid entity: {}. Are you trying to use an entity in a callback in which it's unavailable?", $entity)
+            } else {
+                format!("Missing or invalid entity: {}", $entity)
+            }
+        }
     };
 }
 

--- a/crates/lad_backends/mdbook_lad_preprocessor/src/sections.rs
+++ b/crates/lad_backends/mdbook_lad_preprocessor/src/sections.rs
@@ -622,6 +622,7 @@ impl IntoMarkdown for SectionItem<'_> {
                         </div>
                     "#.trim(),
                     );
+                    builder.append("\n\n");
                 }
 
                 // we don't escape this, this is already markdown


### PR DESCRIPTION
# Summary
Many places in BMS use `Entity::from_raw(0)` as an invalid entity, because that index is not naturally assigned to any entity in Bevy.

When an entity is not available in a callback, i.e. `on_script_loaded` people often try to interact with the entity global, this PR makes it so that using those entities, will throw a more meaningful error and point people to this fact.

Also fixes minor newline issue in docs

