### PR TITLE
feat: Warn on unknown language.

### DIFF
--- a/crates/bevy_mod_scripting_core/src/asset.rs
+++ b/crates/bevy_mod_scripting_core/src/asset.rs
@@ -225,6 +225,14 @@ pub(crate) fn dispatch_script_asset_events(
                         let script_id = converter(path);
 
                         let language = settings.select_script_language(path);
+                        if language == Language::Unknown {
+                            let extension = path
+                                .path()
+                                .extension()
+                                .and_then(|ext| ext.to_str())
+                                .unwrap_or_default();
+                            warn!("A script {:?} was added but its language is unknown. Consider adding the {:?} extension to the `ScriptAssetSettings`.", &script_id, extension);
+                        }
                         let metadata = ScriptMetadata {
                             asset_id: *id,
                             script_id,


### PR DESCRIPTION
# Summary

This change logs a warning when a ScriptAsset is loaded whose language is unknown. It does not alter any behavior.

> WARN A script "main.p8" was added but its language is unknown. Consider adding the "p8" extension to the `ScriptAssetSettings`.

I've had moments where scripts load but nothing happens and it's been tricky to track down. Hopefully this'll help me and other users.