### PR TITLE
chore: don't sync bindings on forks, as they fail

### DIFF
--- a/.github/workflows/bevy_mod_scripting.yml
+++ b/.github/workflows/bevy_mod_scripting.yml
@@ -170,6 +170,7 @@ jobs:
       contents: write
       pull-requests: write
     runs-on: ubuntu-latest
+    if: github.repository_owner == 'makspll'
     steps:
     - name: Checkout
       uses: actions/checkout@v4


### PR DESCRIPTION
# Summary
Eventually this can be updated to work on forks (spit out a diff as a comment?) for now just going to skip on forks
