### PR TITLE
feat: ScriptExecutionOrder component to control script execution order on entities

### DIFF
--- a/crates/bevy_mod_scripting_core/src/script.rs
+++ b/crates/bevy_mod_scripting_core/src/script.rs
@@ -18,6 +18,17 @@ pub type ScriptId = Cow<'static, str>;
 /// Event handlers search for components with this component to figure out which scripts to run and on which entities.
 pub struct ScriptComponent(pub Vec<ScriptId>);
 
+/// Specifies the order in which an entity's [ScriptComponent]'s
+/// script callbacks are executed
+/// relative to the script components on other entities.
+///
+/// Higher values mean later execution.
+/// Equal values have non-deterministic execution order.
+/// If this is not present, a value of 0 is assumed.
+#[derive(bevy::ecs::component::Component, Reflect, Clone, Copy, Ord, PartialOrd, Eq, PartialEq)]
+#[reflect(Component)]
+pub struct ScriptExecutionOrder(pub i32);
+
 impl Deref for ScriptComponent {
     type Target = Vec<ScriptId>;
 


### PR DESCRIPTION
# Summary
This PR adds a `ScriptExecutionOrder` component that, when added to entities with `ScriptComponent`,
specifies the order in which entities are iterated for script traversal.

I require control over script execution order as scripts should be able to build on top of each other's world changes 
in a deterministic way.

Example usage:
```rust
fn spawn_scripts(mut commands: Commands) {
    commands.spawn((
        ScriptComponent::new(vec!["scripts/mod_a.lua"]),
        ScriptExecutionOrder(2), // runs after mod_b
    ));

    commands.spawn((
        ScriptComponent::new(vec!["scripts/mod_b.lua"]),
        ScriptExecutionOrder(1), // runs before mod_a
    ));
}
```

## Caveats
- This system doesn't allow ordering of static script execution

## Considerations
- If this approach is viable, I'll be happy to add some tests and benches
