### PR TITLE
chore: Remove asset_path field from ScriptAsset.

### DIFF
--- a/assets/tests/handle/handle_asset_path_when_script_loaded.lua
+++ b/assets/tests/handle/handle_asset_path_when_script_loaded.lua
@@ -1,6 +1,10 @@
 local expected_asset_path = "tests/handle/handle_asset_path_when_script_loaded.lua"
 function normalize_path(path)
-    return string.gsub(tostring(path), "\\", "/")
+    if path then
+        return string.gsub(path, "\\", "/")
+    else
+        return nil
+    end
 end
 
 local normalized_gotten_asset_path = normalize_path(script_asset:asset_path())

--- a/crates/bevy_mod_scripting_core/src/asset.rs
+++ b/crates/bevy_mod_scripting_core/src/asset.rs
@@ -12,7 +12,7 @@ use crate::{
 };
 use bevy::{
     app::{App, Last},
-    asset::{Asset, AssetEvent, AssetLoader, AssetPath, Assets, LoadState},
+    asset::{Asset, AssetEvent, AssetLoader, Assets, LoadState},
     log::{error, trace, warn, warn_once},
     prelude::{
         AssetServer, Commands, Entity, EventReader, EventWriter, IntoScheduleConfigs, Local, Query,
@@ -59,8 +59,6 @@ pub struct ScriptAsset {
     pub content: Box<[u8]>, // Any chance a Cow<'static, ?> could work here?
     /// The language of the script
     pub language: Language,
-    /// The asset path of the script.
-    pub asset_path: AssetPath<'static>,
 }
 
 impl From<String> for ScriptAsset {
@@ -68,7 +66,6 @@ impl From<String> for ScriptAsset {
         ScriptAsset {
             content: s.into_bytes().into_boxed_slice(),
             language: Language::default(),
-            asset_path: AssetPath::default(),
         }
     }
 }
@@ -168,7 +165,6 @@ impl AssetLoader for ScriptAssetLoader {
         let asset = ScriptAsset {
             content: content.into_boxed_slice(),
             language,
-            asset_path: load_context.asset_path().clone(),
         };
         Ok(asset)
     }

--- a/crates/bevy_mod_scripting_functions/src/core.rs
+++ b/crates/bevy_mod_scripting_functions/src/core.rs
@@ -1257,16 +1257,19 @@ impl Handle<ScriptAsset> {
     /// * `path`: The asset path of the script asset.
     fn asset_path(ctxt: FunctionCallContext, handle: Ref<Handle<ScriptAsset>>) -> Option<String> {
         profiling::function_scope!("path");
-        ctxt.world().ok().and_then(|w| {
-            w.with_resource(|assets: &Assets<ScriptAsset>| {
-                // debug
-                assets
-                    .get(&*handle)
-                    .map(|asset| asset.asset_path.to_string())
+        handle.path()
+            .map(|p| p.to_string())
+            .or_else(|| {
+                ctxt.world().ok().and_then(|w| {
+                    w.with_resource(|asset_server: &AssetServer| {
+                        // debug
+                        asset_server.get_path(&*handle)
+                            .map(|p| p.to_string())
+                    })
+                    .ok()
+                    .flatten()
+                })
             })
-            .ok()
-            .flatten()
-        })
     }
 }
 

--- a/crates/testing_crates/script_integration_test_harness/src/scenario.rs
+++ b/crates/testing_crates/script_integration_test_harness/src/scenario.rs
@@ -700,7 +700,6 @@ impl ScenarioStep {
                     let boxed_byte_arr = content.into_bytes().into_boxed_slice();
                     *existing = ScriptAsset {
                         content: boxed_byte_arr,
-                        asset_path: path.into(),
                         language: existing.language.clone(),
                     };
                 } else {


### PR DESCRIPTION
Congrats on getting 0.14.0 and 0.15.0 releases out! Very exciting.

# Summary
I removed the `asset_path` field from `ScriptAsset` and altered the `script_asset:asset_path()` code to use the path present in the handle or use the path given by the `AssetServer` based on the handle. This preserves the prior behavior and the tests pass.

## Why?

I feel like the asset path is not a property of the asset. It's a property of the handle to the asset, which may or may not have an `AssetPath`. 

The asset to me is like the contents of a file. Some files may declare what they believe their file path to be—and they can be wrong; most files don't. The file's path is an external concern likewise for an asset path.

Also I worry that having the `AssetPath` as a field invites confusion. I know you can summon a path with `AssetPath::default()` but that is effectively wrong or invalid. A field of `Option<AssetPath>` would be less prone to confusion, but I don't think it's warranted or necessary as evidenced by this implementation.

Another reason to prefer not having an `AssetPath` is there are many valid uses that do not have an asset path. Suppose an app uses a string given by the user at runtime to create a `ScriptAsset`. There is no asset path in that case. Procedurally generated cases have similar uses.

## Alternatives

One could use `Option<AssetPath>` as the field to avoid forcing the user to provide a path or provide a default/invalid path.

## Testing

I ran the tests. Found the `script_asset:asset_path()` test failing, which I believe that function is the reason the field exists. I changed its implementation to offer the same results as before but without the field.
