### PR TITLE
refactor: remove `RuntimeContainer` & `RuntimeSettings`, add plugin runtime to static world local settings

### DIFF
--- a/crates/bevy_mod_scripting_core/src/commands.rs
+++ b/crates/bevy_mod_scripting_core/src/commands.rs
@@ -149,32 +149,19 @@ impl<P: IntoScriptPluginParams> CreateOrUpdateScript<P> {
         content: &[u8],
         context: &mut P::C,
         guard: WorldGuard,
-        handler_ctxt: &HandlerContext<P>,
     ) -> Result<(), ScriptError> {
         debug!("{}: reloading context {}", P::LANGUAGE, attachment);
         // reload context
-        P::reload(
-            attachment,
-            content,
-            context,
-            guard.clone(),
-            &handler_ctxt.runtime_container.runtime,
-        )
+        P::reload(attachment, content, context, guard.clone())
     }
 
     fn load_context(
         attachment: &ScriptAttachment,
         content: &[u8],
         guard: WorldGuard,
-        handler_ctxt: &HandlerContext<P>,
     ) -> Result<P::C, ScriptError> {
         debug!("{}: loading context {}", P::LANGUAGE, attachment);
-        let context = P::load(
-            attachment,
-            content,
-            guard.clone(),
-            &handler_ctxt.runtime_container.runtime,
-        )?;
+        let context = P::load(attachment, content, guard.clone())?;
         Ok(context)
     }
 
@@ -272,16 +259,10 @@ impl<P: IntoScriptPluginParams> CreateOrUpdateScript<P> {
             Some(context) => {
                 let mut context = context.lock();
 
-                Self::reload_context(
-                    &attachment,
-                    content,
-                    &mut context,
-                    guard.clone(),
-                    handler_ctxt,
-                )
-                .map(|_| None)
+                Self::reload_context(&attachment, content, &mut context, guard.clone())
+                    .map(|_| None)
             }
-            None => Self::load_context(&attachment, content, guard.clone(), handler_ctxt).map(Some),
+            None => Self::load_context(&attachment, content, guard.clone()).map(Some),
         };
 
         match result_context_to_insert {

--- a/crates/bevy_mod_scripting_core/src/config.rs
+++ b/crates/bevy_mod_scripting_core/src/config.rs
@@ -14,7 +14,7 @@ use crate::{
 /// Configs contained here should be
 ///
 /// *global meaning stored in thread-locals, i.e. not annoyingly global, but pretty global.
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct ScriptingPluginConfiguration<P: IntoScriptPluginParams + ?Sized> {
     /// callbacks executed before a handler callback is executed every time
     pub pre_handling_callbacks: &'static [ContextPreHandlingInitializer<P>],
@@ -22,6 +22,8 @@ pub struct ScriptingPluginConfiguration<P: IntoScriptPluginParams + ?Sized> {
     pub context_initialization_callbacks: &'static [ContextInitializer<P>],
     /// Whether to emit responses from the core callbacks like `on_script_loaded`.
     pub emit_responses: bool,
+    /// The configured runtime for the plugin
+    pub runtime: &'static P::R,
 }
 
 impl<P: IntoScriptPluginParams + ?Sized> Clone for ScriptingPluginConfiguration<P> {

--- a/crates/bevy_mod_scripting_core/src/context.rs
+++ b/crates/bevy_mod_scripting_core/src/context.rs
@@ -50,7 +50,6 @@ pub trait ScriptingLoader<P: IntoScriptPluginParams> {
         attachment: &ScriptAttachment,
         content: &[u8],
         world: WorldGuard,
-        runtime: &P::R,
     ) -> Result<P::C, ScriptError>;
 
     /// Reloads a script context using the provided reloader function
@@ -59,7 +58,6 @@ pub trait ScriptingLoader<P: IntoScriptPluginParams> {
         content: &[u8],
         previous_context: &mut P::C,
         world: WorldGuard,
-        runtime: &P::R,
     ) -> Result<(), ScriptError>;
 }
 
@@ -68,7 +66,6 @@ impl<P: IntoScriptPluginParams> ScriptingLoader<P> for P {
         attachment: &ScriptAttachment,
         content: &[u8],
         world: WorldGuard,
-        runtime: &P::R,
     ) -> Result<P::C, ScriptError> {
         WorldGuard::with_existing_static_guard(world.clone(), |world| {
             let world_id = world.id();
@@ -78,7 +75,7 @@ impl<P: IntoScriptPluginParams> ScriptingLoader<P> for P {
                 content,
                 P::readonly_configuration(world_id).context_initialization_callbacks,
                 P::readonly_configuration(world_id).pre_handling_callbacks,
-                runtime,
+                P::readonly_configuration(world_id).runtime,
             )
         })
     }
@@ -88,7 +85,6 @@ impl<P: IntoScriptPluginParams> ScriptingLoader<P> for P {
         content: &[u8],
         previous_context: &mut P::C,
         world: WorldGuard,
-        runtime: &P::R,
     ) -> Result<(), ScriptError> {
         WorldGuard::with_existing_static_guard(world, |world| {
             let world_id = world.id();
@@ -99,7 +95,7 @@ impl<P: IntoScriptPluginParams> ScriptingLoader<P> for P {
                 previous_context,
                 P::readonly_configuration(world_id).context_initialization_callbacks,
                 P::readonly_configuration(world_id).pre_handling_callbacks,
-                runtime,
+                P::readonly_configuration(world_id).runtime,
             )
         })
     }

--- a/crates/bevy_mod_scripting_core/src/runtime.rs
+++ b/crates/bevy_mod_scripting_core/src/runtime.rs
@@ -1,8 +1,6 @@
 //! "Runtime" here refers to the execution evironment of scripts. This might be the VM executing bytecode or the interpreter executing source code.
 //! The important thing is that there is only one runtime which is used to execute all scripts of a particular type or `context`.
 
-use ::bevy_ecs::{resource::Resource, system::Res, system::ResMut};
-
 use crate::{IntoScriptPluginParams, error::ScriptError};
 
 /// A trait that all script runtimes must implement.
@@ -11,52 +9,3 @@ impl<T: Default + 'static + Send + Sync> Runtime for T {}
 
 /// A function that initializes a runtime.
 pub type RuntimeInitializer<P> = fn(&<P as IntoScriptPluginParams>::R) -> Result<(), ScriptError>;
-
-#[derive(Resource)]
-/// Resource storing settings for a scripting plugin regarding runtime initialization & configuration.
-pub struct RuntimeSettings<P: IntoScriptPluginParams> {
-    /// Initializers for the runtime. These are run when the runtime is initialized.
-    pub initializers: Vec<RuntimeInitializer<P>>,
-}
-
-impl<P: IntoScriptPluginParams> Default for RuntimeSettings<P> {
-    fn default() -> Self {
-        Self {
-            initializers: Default::default(),
-        }
-    }
-}
-
-impl<P: IntoScriptPluginParams> Clone for RuntimeSettings<P> {
-    fn clone(&self) -> Self {
-        Self {
-            initializers: self.initializers.clone(),
-        }
-    }
-}
-
-/// Stores a particular runtime.
-#[derive(Resource)]
-pub struct RuntimeContainer<P: IntoScriptPluginParams> {
-    /// The runtime contained within.
-    pub runtime: P::R,
-}
-
-impl<P: IntoScriptPluginParams> Default for RuntimeContainer<P> {
-    fn default() -> Self {
-        Self {
-            runtime: Default::default(),
-        }
-    }
-}
-
-#[profiling::function]
-pub(crate) fn initialize_runtime<P: IntoScriptPluginParams>(
-    runtime: ResMut<RuntimeContainer<P>>,
-    settings: Res<RuntimeSettings<P>>,
-) -> Result<(), ScriptError> {
-    for initializer in settings.initializers.iter() {
-        (initializer)(&runtime.runtime)?;
-    }
-    Ok(())
-}

--- a/crates/languages/bevy_mod_scripting_lua/src/lib.rs
+++ b/crates/languages/bevy_mod_scripting_lua/src/lib.rs
@@ -19,7 +19,6 @@ use bevy_mod_scripting_core::{
     event::CallbackLabel,
     make_plugin_config_static,
     reflection_extensions::PartialReflectExt,
-    runtime::RuntimeSettings,
     script::{ContextPolicy, ScriptAttachment},
 };
 use bindings::{
@@ -71,7 +70,7 @@ impl Default for LuaScriptingPlugin {
     fn default() -> Self {
         LuaScriptingPlugin {
             scripting_plugin: ScriptingPlugin {
-                runtime_settings: RuntimeSettings::default(),
+                runtime_initializers: Vec::default(),
                 context_initializers: vec![
                     |_script_id, context| {
                         // set the world global

--- a/crates/languages/bevy_mod_scripting_rhai/src/lib.rs
+++ b/crates/languages/bevy_mod_scripting_rhai/src/lib.rs
@@ -22,7 +22,6 @@ use bevy_mod_scripting_core::{
     event::CallbackLabel,
     make_plugin_config_static,
     reflection_extensions::PartialReflectExt,
-    runtime::RuntimeSettings,
     script::{ContextPolicy, DisplayProxy, ScriptAttachment},
 };
 use bindings::{
@@ -88,16 +87,14 @@ impl Default for RhaiScriptingPlugin {
     fn default() -> Self {
         RhaiScriptingPlugin {
             scripting_plugin: ScriptingPlugin {
-                runtime_settings: RuntimeSettings {
-                    initializers: vec![|runtime| {
-                        let mut engine = runtime.write();
-                        engine.set_max_expr_depths(999, 999);
-                        engine.build_type::<RhaiReflectReference>();
-                        engine.build_type::<RhaiStaticReflectReference>();
-                        engine.register_iterator_result::<RhaiReflectReference, _>();
-                        Ok(())
-                    }],
-                },
+                runtime_initializers: vec![|runtime| {
+                    let mut engine = runtime.write();
+                    engine.set_max_expr_depths(999, 999);
+                    engine.build_type::<RhaiReflectReference>();
+                    engine.build_type::<RhaiStaticReflectReference>();
+                    engine.register_iterator_result::<RhaiReflectReference, _>();
+                    Ok(())
+                }],
                 context_initializers: vec![
                     |_, context| {
                         context.scope.set_or_push(

--- a/crates/testing_crates/script_integration_test_harness/src/lib.rs
+++ b/crates/testing_crates/script_integration_test_harness/src/lib.rs
@@ -314,7 +314,7 @@ where
     let ctxt_arc = context.script_context().get(&context_key).unwrap();
     let mut ctxt_locked = ctxt_arc.lock();
 
-    let runtime = &context.runtime_container().runtime;
+    let runtime = P::readonly_configuration(guard.id()).runtime;
 
     let _ = WorldAccessGuard::with_existing_static_guard(guard, |guard| {
         // Ensure the world is available via ThreadWorldContainer


### PR DESCRIPTION
# Summary
Does what #470 did with context loading settings but for the runtime.

Since it's this is something we initialize once and then purely read (or modify through read refs), it can fit this model.

This leaves only 2 resources in the handler context

# Migration Guide

`RuntimeSettings` and `RuntimeContainer` are removed, replace usages with `P::readonly_settings(world.id()).runtime)` access to initializers is no longer possible outside the plugin setup phase