### PR TITLE
refactor: modify `ContextLoadFn` & `ContextReloadFn` & `HandlerFn` to use `WorldId` instead of direct config

### DIFF
--- a/crates/bevy_mod_scripting_core/src/bindings/script_system.rs
+++ b/crates/bevy_mod_scripting_core/src/bindings/script_system.rs
@@ -247,11 +247,10 @@ impl<'w, P: IntoScriptPluginParams> DynamicHandlerContext<'w, P> {
         };
 
         // call the script
-        let runtime = P::readonly_configuration(guard.id()).runtime;
 
         let mut context = context.lock();
 
-        P::handle(payload, context_key, label, &mut context, runtime, guard)
+        P::handle(payload, context_key, label, &mut context, guard)
     }
 }
 

--- a/crates/bevy_mod_scripting_core/src/extractors.rs
+++ b/crates/bevy_mod_scripting_core/src/extractors.rs
@@ -103,12 +103,9 @@ impl<P: IntoScriptPluginParams> HandlerContext<P> {
             return Err(InteropError::missing_context(context_key.clone()).into());
         };
 
-        // call the script
-        let runtime = P::readonly_configuration(guard.id()).runtime;
-
         let mut context = context.lock();
 
-        P::handle(payload, context_key, label, &mut context, runtime, guard)
+        P::handle(payload, context_key, label, &mut context, guard)
     }
 
     /// Invoke a callback in a script immediately.

--- a/crates/testing_crates/test_utils/src/test_plugin.rs
+++ b/crates/testing_crates/test_utils/src/test_plugin.rs
@@ -33,7 +33,9 @@ macro_rules! make_test_plugin {
             }
 
             fn handler() -> $ident::HandlerFn<Self> {
-                (|args, context_key, callback, script_ctxt, pre_handling_initializers, runtime| {
+                (|args, context_key, callback, script_ctxt, world_id| {
+                    let config = TestPlugin::readonly_configuration(world_id);
+                    let runtime = config.runtime;
                     runtime
                         .invocations
                         .lock()
@@ -43,7 +45,7 @@ macro_rules! make_test_plugin {
             }
 
             fn context_loader() -> $ident::ContextLoadFn<Self> {
-                (|attachment, content, context_initializers, pre_handling_initializers, runtime| {
+                (|attachment, content, world_id| {
                     Ok(TestContext {
                         invocations: vec![],
                     })
@@ -51,12 +53,7 @@ macro_rules! make_test_plugin {
             }
 
             fn context_reloader() -> $ident::ContextReloadFn<Self> {
-                (|attachment,
-                  content,
-                  previous_context,
-                  context_initializers,
-                  pre_handling_initializers,
-                  runtime| {
+                (|attachment, content, previous_context, world_id| {
                     previous_context.invocations.clear();
                     Ok(())
                 })


### PR DESCRIPTION
# Summary
All of `ContextLoadFn` `ContextReloadFn` and `HandlerFn` now accept `WorldId` instead of directly requiring the properties available within the static config introduced in #470 . This simplifies signatures, removes the need to retrieve the runtime if you don't need one, and is all around more ergonomic

# Migration Guide
if you implemented a scripting plugin you will need to correct your function signatures for the above aliases, and fetch the config yourself to access callbacks via `Plugin::readonly_configuration(world_id)` using the world id you will now receive.