### PR TITLE
refactor: remove `HandlerCtxt`, wrap `ScriptContext<P>` in Arc

### DIFF
--- a/crates/bevy_mod_scripting_core/src/asset.rs
+++ b/crates/bevy_mod_scripting_core/src/asset.rs
@@ -250,6 +250,7 @@ fn handle_script_events<P: IntoScriptPluginParams>(
 
                     let handle = Handle::Weak(*id);
                     let attachment = ScriptAttachment::StaticScript(handle.clone());
+                    let script_contexts = script_contexts.read();
                     for (resident, _) in script_contexts
                         .residents(&attachment)
                         .filter(|(r, _)| r.script() == handle && r.is_static())

--- a/crates/bevy_mod_scripting_core/src/context.rs
+++ b/crates/bevy_mod_scripting_core/src/context.rs
@@ -6,6 +6,7 @@ use crate::{
     IntoScriptPluginParams,
     bindings::{ThreadWorldContainer, WorldContainer, WorldGuard},
     error::ScriptError,
+    extractors::GetPluginFor,
     script::ScriptAttachment,
 };
 
@@ -13,8 +14,8 @@ use crate::{
 ///
 /// Contexts are not required to be `Sync` as they are internally stored behind a `Mutex` but they must satisfy `Send` so they can be
 /// freely sent between threads.
-pub trait Context: 'static + Send {}
-impl<T: 'static + Send> Context for T {}
+pub trait Context: 'static + Send + GetPluginFor {}
+impl<T: 'static + Send + GetPluginFor> Context for T {}
 
 /// Initializer run once after creating a context but before executing it for the first time as well as after re-loading the script
 pub type ContextInitializer<P> =

--- a/crates/languages/bevy_mod_scripting_rhai/src/lib.rs
+++ b/crates/languages/bevy_mod_scripting_rhai/src/lib.rs
@@ -20,6 +20,7 @@ use bevy_mod_scripting_core::{
     config::{GetPluginThreadConfig, ScriptingPluginConfiguration},
     error::ScriptError,
     event::CallbackLabel,
+    extractors::GetPluginFor,
     make_plugin_config_static,
     reflection_extensions::PartialReflectExt,
     script::{ContextPolicy, DisplayProxy, ScriptAttachment},
@@ -44,6 +45,10 @@ pub struct RhaiScriptContext {
     pub ast: AST,
     /// The scope of the script
     pub scope: Scope<'static>,
+}
+
+impl GetPluginFor for RhaiScriptContext {
+    type P = RhaiScriptingPlugin;
 }
 
 make_plugin_config_static!(RhaiScriptingPlugin);

--- a/crates/testing_crates/script_integration_test_harness/src/scenario.rs
+++ b/crates/testing_crates/script_integration_test_harness/src/scenario.rs
@@ -753,10 +753,12 @@ impl ScenarioStep {
                     #[cfg(feature = "lua")]
                     Some(Language::Lua) => world
                         .resource::<ScriptContext<bevy_mod_scripting_lua::LuaScriptingPlugin>>()
+                        .read()
                         .residents_len(&script),
                     #[cfg(feature = "rhai")]
                     Some(Language::Rhai) => world
                         .resource::<ScriptContext<bevy_mod_scripting_rhai::RhaiScriptingPlugin>>()
+                        .read()
                         .residents_len(&script),
                     _ => {
                         return Err(anyhow!(

--- a/crates/testing_crates/test_utils/src/test_plugin.rs
+++ b/crates/testing_crates/test_utils/src/test_plugin.rs
@@ -20,6 +20,10 @@ macro_rules! make_test_plugin {
 
         $ident::make_plugin_config_static!(TestPlugin);
 
+        impl $ident::extractors::GetPluginFor for TestContext {
+            type P = TestPlugin;
+        }
+
         impl $ident::IntoScriptPluginParams for TestPlugin {
             type C = TestContext;
             type R = TestRuntime;


### PR DESCRIPTION
# Summary
- **ScriptContext API Changes**: Now wrapped in `Arc<RwLock<>>` - access via `.read()` and `.write()` methods; `get()` renamed to `get_context()`; New methods: `get_resident()`, `get_context_and_residency()`
- **HandlerContext Removed**: No longer available - replaced by direct access to `ScriptContext`; `with_handler_system_state()` function removed
- **CallContext Trait**: New trait implemented for all script contexts; Provides `call_context_dynamic()` and `call_context()` methods
- **GetPluginFor Trait**: All context types must now implement this trait; Provides reverse mapping from context to plugin type
- **Lua Type Changes**: Context type changed from `mlua::Lua` to `LuaContext` wrapper; Update all code interacting with Lua contexts
- **RunScriptCallback Changes**: `run_with_handler()` replaced with `run_with_context()` and `run_with_contexts()`
- **Script Creation/Reloading**: Completely restructured script lifecycle methods; New granular API for different script creation/update scenarios

## Migration GUide

- **ScriptContext Access**: Use `.read()` and `.write()` to access ScriptContext (now wrapped in `Arc<RwLock<>>`); replace `get()` with `get_context()`
- **HandlerContext**: Replace with direct ScriptContext access; remove any `with_handler_system_state()` calls
- **Script Callbacks**: Use new `call_context_dynamic()` or `call_context()` methods from the CallContext trait
- **Custom Context Types**: Implement the new `GetPluginFor` trait to provide mapping from context to plugin type
- **Lua Interaction**: Replace `mlua::Lua` with `LuaContext` wrapper type in all Lua code
- **Script Callback Running**: Replace `run_with_handler()` calls with `run_with_context()` or `run_with_contexts()`

