### PR TITLE
feat: Better HashMaps - hashmap iteration and read-access in map_get()

### DIFF
--- a/assets/tests/iter/hashmap.lua
+++ b/assets/tests/iter/hashmap.lua
@@ -1,0 +1,15 @@
+local res_type = world.get_type_by_name("TestResourceWithVariousFields")
+local res = world.get_resource(res_type)
+
+local map = res.string_map
+
+local count = 0
+local found_keys = {}
+for key, value in pairs(map) do
+    count = count + 1
+    found_keys[key] = value
+end
+
+assert(count == 2, "Expected 2 entries, got " .. count)
+assert(found_keys["foo"] == "bar", "Expected foo=>bar")
+assert(found_keys["zoo"] == "zed", "Expected zoo=>zed")

--- a/assets/tests/iter/hashmap.rhai
+++ b/assets/tests/iter/hashmap.rhai
@@ -1,0 +1,31 @@
+let res_type = world.get_type_by_name.call("TestResourceWithVariousFields");
+let res = world.get_resource.call(res_type);
+
+let map = res.string_map;
+
+let iterator = map.iter();
+let count = 0;
+let found_keys = #{};
+
+loop {
+    let result = iterator.next();
+    
+    if result == () {
+        break;
+    }
+    
+    let key = result[0];
+    let value = result[1];
+    count += 1;
+    found_keys[key] = value;
+}
+
+if count != 2 {
+    throw `Expected 2 entries, got ${count}`;
+}
+if found_keys["foo"] != "bar" {
+    throw "Expected foo=>bar";
+}
+if found_keys["zoo"] != "zed" {
+    throw "Expected zoo=>zed";
+}

--- a/crates/languages/bevy_mod_scripting_rhai/src/lib.rs
+++ b/crates/languages/bevy_mod_scripting_rhai/src/lib.rs
@@ -25,7 +25,7 @@ use bevy_mod_scripting_core::{
     make_plugin_config_static,
     script::{ContextPolicy, DisplayProxy, ScriptAttachment},
 };
-use bindings::reference::{ReservedKeyword, RhaiReflectReference, RhaiStaticReflectReference};
+use bindings::reference::{ReservedKeyword, RhaiReflectReference, RhaiStaticReflectReference, RhaiIterator};
 use parking_lot::RwLock;
 pub use rhai;
 
@@ -142,6 +142,7 @@ impl Default for RhaiScriptingPlugin {
                     engine.set_max_expr_depths(999, 999);
                     engine.build_type::<RhaiReflectReference>();
                     engine.build_type::<RhaiStaticReflectReference>();
+                    engine.build_type::<RhaiIterator>();
                     engine.register_iterator_result::<RhaiReflectReference, _>();
                     Ok(())
                 }],


### PR DESCRIPTION
Hey! This PR improves how we work with HashMaps in the scripting layer. Two main things here:

## What changed?

### HashMap iteration support (commit b632625)
Added proper iteration over maps! Now you can do `for key, value in pairs(map)` in Lua and use `.iter()` in Rhai. This was trickier than it looks because Bevy's reflection path system doesn't play nice with maps - it rejects `ListIndex` access on map types. So I added a dedicated `ReflectMapRefIter` that bypasses the path system and uses `Map::get_at()` directly.

The iterator returns `(key, value)` tuples that get properly unpacked in both languages - Lua's `pairs()` just works, and Rhai gets a wrapped iterator with a `next()` method.

### Fixed `map_get()` to use read-only access (commit fc7d746)  
Changed `map_get()` from using `from_reflect()` to `to_dynamic()`. This might seem like a small thing but it's actually pretty important:

- **More reliable**: Works with ALL reflected types now, not just ones that have `ReflectFromReflect` registered. No more mysterious failures when accessing certain map value types.
- **Correct semantics**: Reading from a map doesn't need mutable access! Changed from `with_reflect_mut` to `with_reflect`. This is also groundwork for an upcoming PR that will fix Bevy's change detection by properly checking `ReflectReference` access modes.
- **Better perf**: Eliminates the registry lookup and type reconstruction that `from_reflect()` does. `to_dynamic()` is simpler.

## Testing

Added test scripts for both Lua and Rhai that verify:
- Iterating over map entries
- Getting correct key-value pairs
- Proper entry counts

Existing map operations should all still work as before.