### PR TITLE
chore: bump mlua to 0.11

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -215,7 +215,7 @@ dot-writer = { version = "0.1.4", default-features = false }
 parking_lot = { version = "0.12.1", default-features = false }
 strum = { version = "0.26", default-features = false }
 rhai = { version = "1.21", default-features = false }
-mlua = { version = "0.10", default-features = false }
+mlua = { version = "0.11", default-features = false }
 log = { version = "0.4", default-features = false }
 env_logger = { version = "0.11", default-features = false }
 clap = { version = "4", default-features = false, features = ["std"] }

--- a/crates/languages/bevy_mod_scripting_lua/src/bindings/script_value.rs
+++ b/crates/languages/bevy_mod_scripting_lua/src/bindings/script_value.rs
@@ -111,10 +111,7 @@ impl FromLua for LuaScriptValue {
             Value::Nil => ScriptValue::Unit,
             Value::Boolean(b) => ScriptValue::Bool(b),
             // Value::LightUserData(light_user_data) => todo!(),
-            #[cfg(not(feature = "luau"))]
             Value::Integer(i) => ScriptValue::Integer(i),
-            #[cfg(feature = "luau")]
-            Value::Integer(i) => ScriptValue::Integer(i as i64),
             Value::Number(n) => ScriptValue::Float(n),
             Value::String(s) => ScriptValue::String(s.to_str()?.to_owned().into()),
             Value::Function(f) => ScriptValue::Function(
@@ -187,10 +184,7 @@ impl IntoLua for LuaScriptValue {
         Ok(match self.0 {
             ScriptValue::Unit => Value::Nil,
             ScriptValue::Bool(b) => Value::Boolean(b),
-            #[cfg(not(feature = "luau"))]
             ScriptValue::Integer(i) => Value::Integer(i),
-            #[cfg(feature = "luau")]
-            ScriptValue::Integer(i) => Value::Integer(i as i32),
             ScriptValue::Float(f) => Value::Number(f),
             ScriptValue::String(s) => Value::String(lua.create_string(s.as_ref())?),
             ScriptValue::Reference(r) => LuaReflectReference::from(r).into_lua(lua)?,
@@ -199,8 +193,8 @@ impl IntoLua for LuaScriptValue {
                 .create_function(move |lua, args: MultiLuaScriptValue| {
                     let loc = {
                         profiling::scope!("function call context");
-                        lua.inspect_stack(1).map(|debug| LocationContext {
-                            line: debug.curr_line().try_into().unwrap_or_default(),
+                        lua.inspect_stack(1, |debug| LocationContext {
+                            line: debug.current_line().unwrap_or_default() as u32,
                             col: None,
                             script_name: lua.app_data_ref::<LuaContextAppData>().and_then(|v| {
                                 v.last_loaded_script_name.as_ref().map(|n| n.to_string())
@@ -221,8 +215,8 @@ impl IntoLua for LuaScriptValue {
                 .create_function(move |lua, args: MultiLuaScriptValue| {
                     let loc = {
                         profiling::scope!("function call context");
-                        lua.inspect_stack(1).map(|debug| LocationContext {
-                            line: debug.curr_line().try_into().unwrap_or_default(),
+                        lua.inspect_stack(1, |debug| LocationContext {
+                            line: debug.current_line().unwrap_or_default() as u32,
                             col: None,
                             script_name: lua.app_data_ref::<LuaContextAppData>().and_then(|v| {
                                 v.last_loaded_script_name.as_ref().map(|n| n.to_string())


### PR DESCRIPTION
# Summary
Bumped the mlua dependency to 0.11 with minimal changes. This is useful because mlua 0.11 provides support for Luau's require feature (aliases, VFS), as well as Lua 5.5, and various bug fixes.
